### PR TITLE
Realign MCP HTTP+SSE transport proposal

### DIFF
--- a/documentation/proposals/koan-mcp-http-sse-transport.md
+++ b/documentation/proposals/koan-mcp-http-sse-transport.md
@@ -86,12 +86,13 @@ internal sealed class HttpSseTransport : BackgroundService
 
 | Component | STDIO | HTTP+SSE | Status |
 |-----------|-------|----------|--------|
-| **Transport Layer** | stdin/stdout streams | HTTP POST + SSE stream | ❌ Missing |
+| **Transport Layer** | stdin/stdout streams | HTTP GET (SSE channel) + HTTP POST (JSON-RPC submit) | ❌ Missing |
 | **Message Framing** | HeaderDelimited | SSE events (`data: {...}\n\n`) | ❌ Missing |
 | **Connection Model** | Single session | Multi-client sessions | ❌ Missing |
 | **Authentication** | None (local trust) | Bearer tokens / OAuth | ❌ Missing |
-| **Session Management** | CancellationTokenSource | SseSessionManager | ❌ Missing |
-| **Endpoint Mapping** | N/A | POST /mcp/sse route | ❌ Missing |
+| **Session Management** | CancellationTokenSource | HttpSseSessionManager | ❌ Missing |
+| **Capability Discovery** | `tools/list` (JSON-RPC) | GET `/mcp/capabilities` | ❌ Missing |
+| **Endpoint Mapping** | N/A | GET `/mcp/sse` + POST `/mcp/rpc` + GET `/mcp/capabilities` | ❌ Missing |
 | **CORS Support** | N/A | Configurable origins | ❌ Missing |
 | **Rate Limiting** | N/A | Per-user limits | ❌ Missing |
 | **Health Monitoring** | ✅ IHealthAggregator | ❌ Not implemented |
@@ -101,31 +102,38 @@ internal sealed class HttpSseTransport : BackgroundService
 ### Architecture Overview
 
 ```
-┌─────────────────┐     HTTP POST          ┌──────────────────────────┐
-│  MCP Client     │ ─────────────────────> │  /mcp/sse Endpoint       │
-│  (Browser/IDE)  │ <────────────────────  │  (ASP.NET Core)          │
-└─────────────────┘     SSE Events         └──────────────────────────┘
-                                                       │
-                                                       ▼
-                                            ┌──────────────────────────┐
-                                            │  SseSessionManager       │
-                                            │  - Multi-client tracking │
-                                            │  - Session lifecycle     │
-                                            └──────────────────────────┘
-                                                       │
-                                                       ▼
-                                            ┌──────────────────────────┐
-                                            │  SseTransportDispatcher  │
-                                            │  - JSON-RPC parsing      │
-                                            │  - SSE event formatting  │
-                                            └──────────────────────────┘
-                                                       │
-                                                       ▼
-                                            ┌──────────────────────────┐
-                                            │  EndpointToolExecutor    │
-                                            │  (Shared with STDIO)     │
-                                            └──────────────────────────┘
+┌─────────────────┐       GET /mcp/sse            ┌────────────────────────┐
+│  MCP Client     │ ────────────────────────────> │  SSE Stream Endpoint   │
+│  (Browser/IDE)  │ <═══════════════════════════  │  (ASP.NET Core)        │
+└─────────────────┘        text/event-stream       └────────────────────────┘
+           │                                            │
+           │ POST /mcp/rpc (JSON-RPC 2.0)               ▼
+           └────────────────────────────────────────> ┌──────────────────────────┐
+                                                    │  HttpSseSessionManager    │
+                                                    │  - Concurrency limits     │
+                                                    │  - Heartbeats & health    │
+                                                    └──────────────────────────┘
+                                                               │
+                                                               ▼
+                                                    ┌──────────────────────────┐
+                                                    │  StreamJsonRpc Dispatcher│
+                                                    │  (IMcpTransportDispatcher│
+                                                    │   reused from STDIO)     │
+                                                    └──────────────────────────┘
+                                                               │
+                                                               ▼
+                                                    ┌──────────────────────────┐
+                                                    │  EndpointToolExecutor    │
+                                                    │  (Shared with STDIO)     │
+                                                    └──────────────────────────┘
+
+                  Capability Discovery → GET /mcp/capabilities (JSON summary)
 ```
+
+**Flow summary:**
+1. Client opens a long-lived `GET /mcp/sse` stream (optionally including an `access_token` query parameter when headers are unavailable). The server responds with a `connected` SSE event containing the generated `sessionId`.
+2. Client submits JSON-RPC requests to `POST /mcp/rpc`, passing the `sessionId` via both `X-Mcp-Session` header and `sessionId` query string. The transport emits `ack` events when a request is accepted and streams results/errors over the same SSE channel using the shared `IMcpTransportDispatcher`.
+3. Tooling and health surfaces discover exposed capabilities via `GET /mcp/capabilities`, a simple JSON document mirroring `tools/list` output and transport metadata for compatibility with mainstream SSE deployment patterns.
 
 ### Core Components
 
@@ -133,33 +141,58 @@ internal sealed class HttpSseTransport : BackgroundService
 
 **File:** `src/Koan.Mcp/Extensions/EndpointExtensions.cs`
 
+This endpoint surface mirrors mainstream SSE deployments: a GET endpoint to establish the stream, a separate POST endpoint for upstream JSON payloads, and a discovery GET route that exposes transport metadata for clients that cannot call `tools/list` until the stream is active.
+
 ```csharp
 public static class EndpointExtensions
 {
     public static IEndpointRouteBuilder MapKoanMcpEndpoints(this IEndpointRouteBuilder endpoints)
     {
         var services = endpoints.ServiceProvider;
-        var options = services.GetRequiredService<IOptionsMonitor<McpServerOptions>>().CurrentValue;
+        var optionsMonitor = services.GetRequiredService<IOptionsMonitor<McpServerOptions>>();
+        var options = optionsMonitor.CurrentValue;
 
-        if (!options.EnableHttpSseTransport) return endpoints;
-
-        var route = options.HttpSseRoute ?? "/mcp/sse";
-
-        endpoints.MapPost(route, async (HttpContext context) =>
+        if (!options.EnableHttpSseTransport)
         {
-            var transport = services.GetRequiredService<HttpSseTransport>();
-            await transport.HandleConnectionAsync(context);
-        })
-        .RequireAuthorization() // Conditional based on options.RequireAuthentication
-        .WithName("KoanMcpSse")
-        .WithMetadata(new ProducesAttribute("text/event-stream"));
+            return endpoints;
+        }
+
+        var baseRoute = options.HttpSseRoute?.TrimEnd('/') ?? "/mcp";
+        var httpTransport = services.GetRequiredService<HttpSseTransport>();
+        var capabilityReporter = services.GetRequiredService<IMcpCapabilityReporter>();
+
+        var group = endpoints.MapGroup(baseRoute);
+        if (options.RequireAuthentication)
+        {
+            group.RequireAuthorization();
+        }
+
+        group.MapGet("sse", httpTransport.AcceptStreamAsync)
+             .Produces("text/event-stream")
+             .WithName("KoanMcpSseStream");
+
+        group.MapPost("rpc", httpTransport.SubmitRequestAsync)
+             .Accepts<JsonRpcRequest>("application/json")
+             .Produces("application/json")
+             .WithName("KoanMcpRpcSubmit");
+
+        if (options.PublishCapabilityEndpoint)
+        {
+            group.MapGet("capabilities", async context =>
+            {
+                var payload = await capabilityReporter.GetCapabilitiesAsync(context.RequestAborted);
+                await context.Response.WriteAsJsonAsync(payload);
+            })
+            .Produces("application/json")
+            .WithName("KoanMcpCapabilities");
+        }
 
         return endpoints;
     }
 }
 ```
 
-**Auto-Registration** (via `KoanWebStartupFilter`):
+**Auto-Registration** (via `KoanWebStartupFilter`, sharing the existing routing block):
 ```csharp
 public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
 {
@@ -167,190 +200,376 @@ public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
     {
         next(app);
 
-        var mcpOptions = app.ApplicationServices.GetService<IOptions<McpServerOptions>>()?.Value;
-        if (mcpOptions?.EnableHttpSseTransport == true)
+        app.UseEndpoints(endpoints =>
         {
-            app.UseEndpoints(endpoints => endpoints.MapKoanMcpEndpoints());
-        }
+            endpoints.MapKoanEndpoints();       // existing REST/GraphQL wiring
+            endpoints.MapKoanMcpEndpoints();    // HTTP+SSE transport routed in the same block
+        });
     };
 }
 ```
 
 #### 2. Session Management
 
-**File:** `src/Koan.Mcp/Hosting/SseSessionManager.cs`
+**File:** `src/Koan.Mcp/Hosting/HttpSseSessionManager.cs`
 
 ```csharp
-public sealed class SseSessionManager
+public sealed class HttpSseSessionManager : IHostedService, IDisposable
 {
-    private readonly ConcurrentDictionary<string, SseSession> _sessions = new();
+    private readonly ConcurrentDictionary<string, HttpSseSession> _sessions = new();
+    private readonly IOptionsMonitor<McpServerOptions> _options;
+    private readonly ISystemClock _clock;
+    private readonly IHealthAggregator _health;
+    private Timer? _heartbeatTimer;
 
-    public SseSession CreateSession(HttpContext httpContext)
+    public HttpSseSessionManager(
+        IOptionsMonitor<McpServerOptions> options,
+        ISystemClock clock,
+        IHealthAggregator health)
     {
-        var sessionId = Guid.NewGuid().ToString("N");
-        var session = new SseSession
-        {
-            SessionId = sessionId,
-            User = httpContext.User,
-            ResponseStream = httpContext.Response.Body,
-            Cancellation = CancellationTokenSource.CreateLinkedTokenSource(httpContext.RequestAborted),
-            CreatedAt = DateTimeOffset.UtcNow,
-            LastActivityAt = DateTimeOffset.UtcNow
-        };
-
-        _sessions.TryAdd(sessionId, session);
-        return session;
+        _options = options;
+        _clock = clock;
+        _health = health;
     }
 
-    public void CloseSession(string sessionId) { /* ... */ }
-    public SseSession? GetSession(string sessionId) { /* ... */ }
-    public IEnumerable<SseSession> GetActiveSessions() { /* ... */ }
-    public int ActiveSessionCount => _sessions.Count;
+    public bool TryOpenSession(HttpContext context, out HttpSseSession session)
+    {
+        var limit = _options.CurrentValue.MaxConcurrentConnections;
+        if (_sessions.Count >= limit)
+        {
+            session = default!;
+            return false;
+        }
+
+        var id = Guid.NewGuid().ToString("n");
+        session = new HttpSseSession(
+            id,
+            context.User,
+            context.Response.Body,
+            CancellationTokenSource.CreateLinkedTokenSource(context.RequestAborted),
+            _clock.UtcNow);
+
+        if (!_sessions.TryAdd(id, session))
+        {
+            session.Dispose();
+            return false;
+        }
+
+        _health.Publish(new McpTransportHealthSnapshot(
+            activeConnections: _sessions.Count,
+            lastChangeUtc: _clock.UtcNow));
+
+        return true;
+    }
+
+    public bool TryGet(string sessionId, out HttpSseSession session)
+        => _sessions.TryGetValue(sessionId, out session);
+
+    public void CloseSession(HttpSseSession session)
+    {
+        if (_sessions.TryRemove(session.Id, out _))
+        {
+            session.Complete();
+            session.Dispose();
+            _health.Publish(new McpTransportHealthSnapshot(
+                activeConnections: _sessions.Count,
+                lastChangeUtc: _clock.UtcNow));
+        }
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _heartbeatTimer = new Timer(_ => BroadcastHeartbeat(), null,
+            _options.CurrentValue.Transport.SseKeepAliveInterval,
+            _options.CurrentValue.Transport.SseKeepAliveInterval);
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _heartbeatTimer?.Dispose();
+        foreach (var session in _sessions.Values)
+        {
+            session.Cancellation.Cancel();
+            session.Complete();
+        }
+        return Task.CompletedTask;
+    }
+
+    private void BroadcastHeartbeat()
+    {
+        var payload = new { timestamp = _clock.UtcNow };
+        foreach (var session in _sessions.Values)
+        {
+            session.Enqueue(ServerSentEvent.Heartbeat(payload));
+        }
+    }
+
+    public void Dispose() => _heartbeatTimer?.Dispose();
 }
 
-public sealed class SseSession
+public readonly record struct McpTransportHealthSnapshot(int ActiveConnections, DateTimeOffset LastChangeUtc)
+    : IHealthPayload;
+
+public sealed class HttpSseSession : IDisposable
 {
-    public required string SessionId { get; init; }
-    public required ClaimsPrincipal User { get; init; }
-    public required Stream ResponseStream { get; init; }
-    public required CancellationTokenSource Cancellation { get; init; }
-    public required DateTimeOffset CreatedAt { get; init; }
-    public DateTimeOffset LastActivityAt { get; set; }
+    private readonly Channel<ServerSentEvent> _outbound = Channel.CreateUnbounded<ServerSentEvent>();
+
+    internal HttpSseSession(
+        string id,
+        ClaimsPrincipal user,
+        Stream responseStream,
+        CancellationTokenSource cancellation,
+        DateTimeOffset createdAt)
+    {
+        Id = id;
+        User = user;
+        ResponseStream = responseStream;
+        Cancellation = cancellation;
+        CreatedAt = createdAt;
+        LastActivityUtc = createdAt;
+    }
+
+    public string Id { get; }
+    public ClaimsPrincipal User { get; }
+    public Stream ResponseStream { get; }
+    public CancellationTokenSource Cancellation { get; }
+    public DateTimeOffset CreatedAt { get; }
+    public DateTimeOffset LastActivityUtc { get; private set; }
+
+    private HttpSseRpcBridge? _bridge;
+
+    public ValueTask<ServerSentEvent> DequeueAsync(CancellationToken ct)
+        => _outbound.Reader.ReadAsync(ct);
+
+    public IAsyncEnumerable<ServerSentEvent> OutboundMessages(CancellationToken ct)
+        => _outbound.Reader.ReadAllAsync(ct);
+
+    public void Enqueue(ServerSentEvent message)
+    {
+        LastActivityUtc = DateTimeOffset.UtcNow;
+        _outbound.Writer.TryWrite(message);
+    }
+
+    public void AttachBridge(HttpSseRpcBridge bridge) => _bridge = bridge;
+    public HttpSseRpcBridge Bridge => _bridge ?? throw new InvalidOperationException("Session bridge not initialised");
+
+    public void Complete() => _outbound.Writer.TryComplete();
+
+    public void Dispose() => Cancellation.Dispose();
 }
 ```
 
-#### 3. SSE Transport Dispatcher
+#### 3. StreamJsonRpc Bridge
 
-**File:** `src/Koan.Mcp/Hosting/SseTransportDispatcher.cs`
+**File:** `src/Koan.Mcp/Hosting/HttpSseRpcBridge.cs`
 
 ```csharp
-public interface ISseTransportDispatcher
+public sealed class HttpSseRpcBridge : IAsyncDisposable
 {
-    Task HandleRequestAsync(
-        HttpContext httpContext,
-        McpRpcHandler handler,
-        CancellationToken cancellationToken);
-}
+    private readonly Channel<JsonRpcMessage> _inbound = Channel.CreateUnbounded<JsonRpcMessage>();
+    private readonly JsonRpc _rpc;
 
-public sealed class SseTransportDispatcher : ISseTransportDispatcher
-{
-    public async Task HandleRequestAsync(HttpContext httpContext, McpRpcHandler handler, CancellationToken ct)
+    public HttpSseRpcBridge(
+        IMcpTransportDispatcher dispatcher,
+        HttpSseSession session,
+        ILogger<HttpSseRpcBridge> logger)
     {
-        // 1. Parse JSON-RPC request from POST body
-        var requestJson = await new StreamReader(httpContext.Request.Body).ReadToEndAsync(ct);
-        var requestNode = JsonNode.Parse(requestJson) as JsonObject;
-
-        var method = requestNode?["method"]?.GetValue<string>();
-        var paramsNode = requestNode?["params"] as JsonObject;
-        var id = requestNode?["id"];
-
-        // 2. Route to handler method
-        object result = method switch
-        {
-            "tools/list" => await handler.ListToolsAsync(ct),
-            "tools/call" => await handler.CallToolAsync(
-                JsonSerializer.Deserialize<McpRpcHandler.ToolsCallParams>(paramsNode?.ToJsonString() ?? "{}"),
-                ct),
-            _ => throw new InvalidOperationException($"Unknown method: {method}")
-        };
-
-        // 3. Format as SSE event
-        await WriteSseEventAsync(httpContext.Response.Body, "result", new
-        {
-            jsonrpc = "2.0",
-            id = id,
-            result = result
-        });
+        var handler = new SseJsonRpcMessageHandler(session, _inbound);
+        _rpc = new JsonRpc(handler, dispatcher);
+        _rpc.TraceSource.Switch.Level = SourceLevels.Information;
+        _rpc.StartListening();
     }
 
-    private static async Task WriteSseEventAsync(Stream stream, string eventName, object data)
+    public ValueTask SubmitAsync(JsonRpcRequest request, CancellationToken cancellationToken)
+        => _inbound.Writer.WriteAsync(request, cancellationToken);
+
+    public Task Completion => _rpc.Completion;
+
+    public async ValueTask DisposeAsync()
     {
-        var json = JsonSerializer.Serialize(data);
-        var sseData = $"event: {eventName}\ndata: {json}\n\n";
-        var bytes = Encoding.UTF8.GetBytes(sseData);
-        await stream.WriteAsync(bytes);
-        await stream.FlushAsync();
+        _inbound.Writer.TryComplete();
+        try
+        {
+            await _rpc.Completion.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
+}
+
+internal sealed class SseJsonRpcMessageHandler : IJsonRpcMessageHandler
+{
+    private readonly HttpSseSession _session;
+    private readonly Channel<JsonRpcMessage> _inbound;
+
+    public SseJsonRpcMessageHandler(HttpSseSession session, Channel<JsonRpcMessage> inbound)
+    {
+        _session = session;
+        _inbound = inbound;
+    }
+
+    public async ValueTask<JsonRpcMessage> ReadAsync(CancellationToken cancellationToken)
+    {
+        return await _inbound.Reader.ReadAsync(cancellationToken);
+    }
+
+    public ValueTask WriteAsync(JsonRpcMessage content, CancellationToken cancellationToken)
+    {
+        _session.Enqueue(ServerSentEvent.FromJsonRpc(content));
+        return ValueTask.CompletedTask;
+    }
+
+    public void Dispose() { }
+}
+```
+
+#### 4. Server-Sent Event Primitives
+
+**File:** `src/Koan.Mcp/Hosting/ServerSentEvent.cs`
+
+```csharp
+public readonly record struct ServerSentEvent(string Event, JsonNode Payload)
+{
+    public static ServerSentEvent Connected(string sessionId, DateTimeOffset timestamp) =>
+        new("connected", JsonNode.Parse(JsonSerializer.Serialize(new
+        {
+            sessionId,
+            timestamp
+        }))!);
+
+    public static ServerSentEvent Heartbeat(object payload) =>
+        new("heartbeat", JsonNode.Parse(JsonSerializer.Serialize(payload))!);
+
+    public static ServerSentEvent FromJsonRpc(JsonRpcMessage message) =>
+        new(message is JsonRpcError ? "error" : "result",
+            JsonNode.Parse(JsonSerializer.Serialize(message))!);
+
+    public static ServerSentEvent Acknowledged(object? id) =>
+        new("ack", JsonNode.Parse(JsonSerializer.Serialize(new { id }))!);
+
+    public string ToWireFormat()
+    {
+        using var buffer = new ArrayBufferWriter<byte>();
+        using var writer = new Utf8JsonWriter(buffer);
+        Payload.WriteTo(writer);
+        writer.Flush();
+
+        var builder = new StringBuilder()
+            .Append("event: ").Append(Event).Append('\n')
+            .Append("data: ").Append(Encoding.UTF8.GetString(buffer.WrittenSpan)).Append("\n\n");
+
+        return builder.ToString();
     }
 }
 ```
 
-#### 4. HTTP+SSE Transport Implementation
+```csharp
+internal static class HttpSseHeaders
+{
+    public const string SessionId = "X-Mcp-Session";
+}
+```
+
+#### 5. HTTP+SSE Transport Implementation
 
 **File:** `src/Koan.Mcp/Hosting/HttpSseTransport.cs` (replace placeholder)
 
 ```csharp
 public sealed class HttpSseTransport
 {
-    private readonly McpServer _server;
-    private readonly SseSessionManager _sessionManager;
-    private readonly ISseTransportDispatcher _dispatcher;
-    private readonly IOptionsMonitor<McpServerOptions> _optionsMonitor;
+    private readonly HttpSseSessionManager _sessions;
+    private readonly IMcpTransportDispatcher _dispatcher;
+    private readonly IOptionsMonitor<McpServerOptions> _options;
+    private readonly ISystemClock _clock;
     private readonly ILogger<HttpSseTransport> _logger;
 
-    public async Task HandleConnectionAsync(HttpContext httpContext)
+    public HttpSseTransport(
+        HttpSseSessionManager sessions,
+        IMcpTransportDispatcher dispatcher,
+        IOptionsMonitor<McpServerOptions> options,
+        ISystemClock clock,
+        ILogger<HttpSseTransport> logger)
     {
-        var options = _optionsMonitor.CurrentValue;
+        _sessions = sessions;
+        _dispatcher = dispatcher;
+        _options = options;
+        _clock = clock;
+        _logger = logger;
+    }
 
-        // 1. Authentication check
-        if (options.RequireAuthentication && httpContext.User?.Identity?.IsAuthenticated != true)
+    public async Task AcceptStreamAsync(HttpContext context)
+    {
+        var options = _options.CurrentValue;
+
+        if (options.RequireAuthentication && context.User?.Identity?.IsAuthenticated != true)
         {
-            httpContext.Response.StatusCode = 401;
-            await httpContext.Response.WriteAsJsonAsync(new { error = "unauthorized" });
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            await context.Response.WriteAsJsonAsync(new { error = "unauthorized" });
             return;
         }
 
-        // 2. Setup SSE headers
-        httpContext.Response.ContentType = "text/event-stream";
-        httpContext.Response.Headers.CacheControl = "no-cache";
-        httpContext.Response.Headers.Connection = "keep-alive";
-        httpContext.Response.Headers["X-Accel-Buffering"] = "no"; // Nginx compatibility
+        if (!_sessions.TryOpenSession(context, out var session))
+        {
+            context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+            await context.Response.WriteAsJsonAsync(new { error = "max_connections_exceeded" });
+            return;
+        }
 
-        // 3. Create session
-        var session = _sessionManager.CreateSession(httpContext);
-        _logger.LogInformation("MCP SSE session {SessionId} created for user {User}",
-            session.SessionId, httpContext.User?.Identity?.Name ?? "anonymous");
+        context.Response.ContentType = "text/event-stream";
+        context.Response.Headers.CacheControl = "no-cache";
+        context.Response.Headers.Connection = "keep-alive";
+        context.Response.Headers["X-Accel-Buffering"] = "no";
+
+        await using var bridge = new HttpSseRpcBridge(_dispatcher, session, _logger);
+        session.AttachBridge(bridge);
+        session.Enqueue(ServerSentEvent.Connected(session.Id, _clock.UtcNow));
 
         try
         {
-            // 4. Send connection event
-            await WriteSseEventAsync(httpContext.Response.Body, "connected", new
+            await foreach (var evt in session.OutboundMessages(context.RequestAborted))
             {
-                sessionId = session.SessionId,
-                timestamp = DateTimeOffset.UtcNow
-            });
-
-            // 5. Process request via dispatcher
-            var handler = _server.CreateHandler();
-            await _dispatcher.HandleRequestAsync(httpContext, handler, httpContext.RequestAborted);
-
-            // 6. Send completion event
-            await WriteSseEventAsync(httpContext.Response.Body, "end", new
-            {
-                timestamp = DateTimeOffset.UtcNow
-            });
+                await context.Response.WriteAsync(evt.ToWireFormat(), context.RequestAborted);
+                await context.Response.Body.FlushAsync(context.RequestAborted);
+            }
         }
-        catch (Exception ex)
+        catch (OperationCanceledException)
         {
-            _logger.LogError(ex, "Error in MCP SSE session {SessionId}", session.SessionId);
-            await WriteSseEventAsync(httpContext.Response.Body, "error", new
-            {
-                code = "internal_error",
-                message = "An unexpected error occurred"
-            });
+            _logger.LogDebug("MCP SSE session {SessionId} cancelled", session.Id);
         }
         finally
         {
-            _sessionManager.CloseSession(session.SessionId);
+            _sessions.CloseSession(session);
         }
     }
 
-    private static async Task WriteSseEventAsync(Stream stream, string eventName, object data)
+    public async Task<IResult> SubmitRequestAsync(HttpContext context)
     {
-        var json = JsonSerializer.Serialize(data);
-        var sseData = $"event: {eventName}\ndata: {json}\n\n";
-        var bytes = Encoding.UTF8.GetBytes(sseData);
-        await stream.WriteAsync(bytes);
-        await stream.FlushAsync();
+        var sessionId = context.Request.Headers[HttpSseHeaders.SessionId];
+        if (StringValues.IsNullOrEmpty(sessionId))
+        {
+            sessionId = context.Request.Query["sessionId"];
+        }
+
+        if (StringValues.IsNullOrEmpty(sessionId) || !_sessions.TryGet(sessionId!, out var session))
+        {
+            return Results.NotFound(new { error = "unknown_session" });
+        }
+
+        using var reader = new StreamReader(context.Request.Body, Encoding.UTF8);
+        var json = await reader.ReadToEndAsync();
+        var request = JsonSerializer.Deserialize<JsonRpcRequest>(json);
+
+        if (request is null)
+        {
+            return Results.BadRequest(new { error = "invalid_jsonrpc" });
+        }
+
+        await session.Bridge.SubmitAsync(request, context.RequestAborted);
+        session.Enqueue(ServerSentEvent.Acknowledged(request.Id));
+
+        return Results.Accepted($"{context.Request.Path}?sessionId={session.Id}");
     }
 }
 ```
@@ -367,7 +586,7 @@ public sealed class McpServerOptions
 
     // New HTTP+SSE config
     public bool EnableHttpSseTransport { get; set; } = false; // Opt-in for security
-    public string HttpSseRoute { get; set; } = "/mcp/sse";
+    public string HttpSseRoute { get; set; } = "/mcp";
 
     // Authentication
     private bool? _requireAuthentication;
@@ -388,12 +607,18 @@ public sealed class McpServerOptions
     // Transport-specific settings
     public McpTransportOptions Transport { get; set; } = new();
 
+    // Capability discovery endpoint toggle
+    public bool PublishCapabilityEndpoint { get; set; } = true;
+
     // Existing options...
     public ISet<string> AllowedEntities { get; } = new HashSet<string>();
     public ISet<string> DeniedEntities { get; } = new HashSet<string>();
     public Dictionary<string, McpEntityOverride> EntityOverrides { get; } = new();
 }
 ```
+
+- `HttpSseRoute` now represents the route prefix (default `/mcp`), producing `/mcp/sse`, `/mcp/rpc`, and `/mcp/capabilities`.
+- `PublishCapabilityEndpoint` toggles the discovery endpoint for environments that restrict anonymous metadata exposure.
 
 **Extend:** `src/Koan.Mcp/Options/McpTransportOptions.cs`
 
@@ -408,6 +633,36 @@ public sealed class McpTransportOptions
     // New HTTP+SSE specific
     public int SseBufferSize { get; set; } = 8192;
     public TimeSpan SseKeepAliveInterval { get; set; } = TimeSpan.FromSeconds(15);
+}
+```
+
+**Extend:** `src/Koan.Mcp/McpEntityAttribute.cs`
+
+```csharp
+[Flags]
+public enum McpTransportMode
+{
+    None = 0,
+    Stdio = 1,
+    HttpSse = 2,
+    All = Stdio | HttpSse
+}
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+public sealed class McpEntityAttribute : Attribute
+{
+    // Existing members...
+
+    public bool? RequireAuthentication { get; set; }
+    public McpTransportMode EnabledTransports { get; set; } = McpTransportMode.All;
+}
+
+public sealed class McpEntityOverride
+{
+    // Existing members...
+
+    public bool? RequireAuthentication { get; set; }
+    public McpTransportMode? EnabledTransports { get; set; }
 }
 ```
 
@@ -426,9 +681,10 @@ public static IServiceCollection AddKoanMcp(this IServiceCollection services, IC
     services.AddHostedService<StdioTransport>();
 
     // New HTTP+SSE registrations
-    services.TryAddSingleton<SseSessionManager>();
-    services.TryAddSingleton<ISseTransportDispatcher, SseTransportDispatcher>();
+    services.TryAddSingleton<HttpSseSessionManager>();
+    services.AddHostedService(sp => sp.GetRequiredService<HttpSseSessionManager>());
     services.TryAddSingleton<HttpSseTransport>();
+    services.TryAddSingleton<IMcpCapabilityReporter, HttpSseCapabilityReporter>();
 
     // CORS (conditional)
     var options = configuration?.GetSection("Koan:Mcp").Get<McpServerOptions>();
@@ -440,13 +696,116 @@ public static IServiceCollection AddKoanMcp(this IServiceCollection services, IC
             {
                 policy.WithOrigins(options.AllowedOrigins)
                       .AllowCredentials()
-                      .WithHeaders("Authorization", "Content-Type")
-                      .WithMethods("POST", "OPTIONS");
+                      .WithHeaders("Authorization", "Content-Type", HttpSseHeaders.SessionId)
+                      .WithMethods("GET", "POST", "OPTIONS");
             });
         });
     }
 
     return services;
+}
+```
+
+**File:** `src/Koan.Mcp/Diagnostics/IMcpCapabilityReporter.cs`
+
+```csharp
+public interface IMcpCapabilityReporter
+{
+    Task<McpCapabilityDocument> GetCapabilitiesAsync(CancellationToken cancellationToken);
+}
+
+public sealed class HttpSseCapabilityReporter : IMcpCapabilityReporter
+{
+    private readonly McpEntityRegistry _registry;
+    private readonly IOptionsMonitor<McpServerOptions> _options;
+
+    public HttpSseCapabilityReporter(
+        McpEntityRegistry registry,
+        IOptionsMonitor<McpServerOptions> options)
+    {
+        _registry = registry;
+        _options = options;
+    }
+
+    public Task<McpCapabilityDocument> GetCapabilitiesAsync(CancellationToken cancellationToken)
+    {
+        var options = _options.CurrentValue;
+        var tools = _registry.GetAll().Select(entity => new McpCapabilityTool
+        {
+            Name = entity.Name,
+            Description = entity.Description,
+            RequireAuthentication = entity.RequireAuthentication ?? options.RequireAuthentication,
+            EnabledTransports = entity.EnabledTransports
+        }).ToArray();
+
+        return Task.FromResult(new McpCapabilityDocument
+        {
+            Version = "2.0",
+            Transports = new[]
+            {
+                new McpTransportDescription
+                {
+                    Kind = "http+sse",
+                    StreamEndpoint = options.HttpSseRoute.TrimEnd('/') + "/sse",
+                    SubmitEndpoint = options.HttpSseRoute.TrimEnd('/') + "/rpc",
+                    CapabilityEndpoint = options.PublishCapabilityEndpoint
+                        ? options.HttpSseRoute.TrimEnd('/') + "/capabilities" : null,
+                    RequireAuthentication = options.RequireAuthentication
+                }
+            },
+            Tools = tools
+        });
+    }
+}
+```
+
+```csharp
+public sealed record McpCapabilityDocument
+{
+    public string Version { get; init; } = "2.0";
+    public IReadOnlyList<McpTransportDescription> Transports { get; init; } = Array.Empty<McpTransportDescription>();
+    public IReadOnlyList<McpCapabilityTool> Tools { get; init; } = Array.Empty<McpCapabilityTool>();
+}
+
+public sealed record McpTransportDescription
+{
+    public required string Kind { get; init; }
+    public required string StreamEndpoint { get; init; }
+    public required string SubmitEndpoint { get; init; }
+    public string? CapabilityEndpoint { get; init; }
+    public bool RequireAuthentication { get; init; }
+}
+
+public sealed record McpCapabilityTool
+{
+    public required string Name { get; init; }
+    public string? Description { get; init; }
+    public bool RequireAuthentication { get; init; }
+    public McpTransportMode EnabledTransports { get; init; } = McpTransportMode.All;
+}
+```
+
+**Update:** `src/Koan.Mcp/Hosting/KoanMcpAutoRegistrar.cs`
+
+```csharp
+public Task RegisterAsync(IBootReportWriter writer, CancellationToken cancellationToken)
+{
+    var options = _options.CurrentValue;
+
+    writer.Section("Model Context Protocol", section =>
+    {
+        section.Property("STDIO", options.EnableStdioTransport ? "enabled" : "disabled");
+        section.Property("HTTP+SSE", options.EnableHttpSseTransport ? "enabled" : "disabled");
+
+        if (options.EnableHttpSseTransport)
+        {
+            section.Property("Route", options.HttpSseRoute);
+            section.Property("Requires Authentication", options.RequireAuthentication);
+            section.Property("Capability Endpoint", options.PublishCapabilityEndpoint);
+        }
+    });
+
+    return Task.CompletedTask;
 }
 ```
 
@@ -500,8 +859,9 @@ public sealed class TrialSite : Entity<TrialSite>
       "EnableStdioTransport": false,     // Disable local access
       "EnableHttpSseTransport": true,
       "RequireAuthentication": true,     // ✅ Enforced
-      "HttpSseRoute": "/mcp/sse",
+      "HttpSseRoute": "/mcp",
       "MaxConcurrentConnections": 1000,
+      "PublishCapabilityEndpoint": true,
       "EnableCors": true,
       "AllowedOrigins": ["https://ide.example.com"]
     }
@@ -571,51 +931,105 @@ async function authenticate(): Promise<string> {
   return (await response.json()).access_token;
 }
 
+type PendingRequest = {
+  resolve: (value: any) => void;
+  reject: (reason: Error) => void;
+};
+
 // 2. MCP Client
 class KoanMcpClient {
-  constructor(private baseUrl: string, private token?: string) {}
+  private eventSource?: EventSource;
+  private sessionId?: string;
+  private requestId = 1;
+  private readonly pending = new Map<number, PendingRequest>();
+
+  constructor(private readonly baseUrl: string, private readonly token?: string) {}
+
+  private async ensureConnected(): Promise<void> {
+    if (this.eventSource && this.sessionId) {
+      return;
+    }
+
+    const url = new URL('/mcp/sse', this.baseUrl);
+    if (this.token) {
+      url.searchParams.set('access_token', this.token);
+    }
+
+    this.eventSource = new EventSource(url.toString(), { withCredentials: true });
+
+    await new Promise<void>((resolve, reject) => {
+      this.eventSource!.addEventListener('connected', event => {
+        const payload = JSON.parse((event as MessageEvent).data);
+        this.sessionId = payload.sessionId;
+        resolve();
+      }, { once: true });
+
+      this.eventSource!.addEventListener('error', () => {
+        reject(new Error('Failed to establish MCP SSE session.'));
+      }, { once: true });
+    });
+
+    this.eventSource.addEventListener('result', event => {
+      const message = JSON.parse((event as MessageEvent).data);
+      const pending = this.pending.get(message.id);
+      if (pending) {
+        pending.resolve(message.result);
+        this.pending.delete(message.id);
+      }
+    });
+
+    this.eventSource.addEventListener('ack', event => {
+      const message = JSON.parse((event as MessageEvent).data);
+      console.debug('MCP request acknowledged', message.id);
+    });
+
+    this.eventSource.addEventListener('error', event => {
+      const message = JSON.parse((event as MessageEvent).data);
+      const pending = this.pending.get(message.id ?? 0);
+      if (pending) {
+        pending.reject(new Error(message.error?.message ?? 'Unknown MCP error'));
+        this.pending.delete(message.id ?? 0);
+      }
+    });
+  }
 
   async callTool(toolName: string, params: any): Promise<any> {
-    const headers: any = {
+    await this.ensureConnected();
+    if (!this.sessionId) {
+      throw new Error('MCP session not established');
+    }
+
+    const id = this.requestId++;
+    const payload = {
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: { name: toolName, arguments: params },
+      id
+    };
+
+    const headers: Record<string, string> = {
       'Content-Type': 'application/json',
-      'Accept': 'text/event-stream'
+      'X-Mcp-Session': this.sessionId
     };
 
     if (this.token) {
       headers['Authorization'] = `Bearer ${this.token}`;
     }
 
-    const response = await fetch(`${this.baseUrl}/mcp/sse`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({
-        jsonrpc: '2.0',
-        method: 'tools/call',
-        params: { name: toolName, arguments: params },
-        id: Date.now()
-      })
+    const submitUrl = new URL('/mcp/rpc', this.baseUrl);
+    submitUrl.searchParams.set('sessionId', this.sessionId);
+
+    const completion = new Promise<any>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
     });
 
-    return this.parseSSEResponse(response);
-  }
+    await fetch(submitUrl.toString(), {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload)
+    });
 
-  private async parseSSEResponse(response: Response): Promise<any> {
-    const reader = response.body!.getReader();
-    const decoder = new TextDecoder();
-
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-
-      const text = decoder.decode(value);
-      const event = this.extractSSEEvent(text);
-
-      if (event?.type === 'result') {
-        return event.data.result;
-      } else if (event?.type === 'error') {
-        throw new Error(event.data.message);
-      }
-    }
+    return completion;
   }
 }
 
@@ -627,43 +1041,91 @@ const sites = await client.callTool('TrialSite_List', { pageSize: 10 });
 console.log(sites);
 ```
 
+> ℹ️ When running in a browser, use an `EventSource` polyfill (e.g., `eventsource-polyfill`) if you need to set authorization headers; otherwise rely on HTTPS cookies or the temporary `access_token` query parameter demonstrated above.
+
 #### Python Client
 
 ```python
+import json
+import time
 import requests
 import sseclient  # pip install sseclient-py
 
-class KoanMcpClient:
-    def __init__(self, base_url, token=None):
-        self.base_url = base_url
-        self.token = token
 
-    def call_tool(self, tool_name, params):
+class KoanMcpClient:
+    def __init__(self, base_url: str, token: str | None = None) -> None:
+        self.base_url = base_url.rstrip('/')
+        self.token = token
+        self._sse_client: sseclient.SSEClient | None = None
+        self._session_id: str | None = None
+
+    def _ensure_connected(self) -> None:
+        if self._sse_client and self._session_id:
+            return
+
+        headers = {'Accept': 'text/event-stream'}
+        params = {}
+        if self.token:
+            headers['Authorization'] = f'Bearer {self.token}'
+            params['access_token'] = self.token
+
+        response = requests.get(
+            f"{self.base_url}/mcp/sse",
+            headers=headers,
+            params=params,
+            stream=True,
+            timeout=30,
+        )
+        response.raise_for_status()
+
+        client = sseclient.SSEClient(response)
+        for event in client.events():
+            if event.event == 'connected':
+                payload = json.loads(event.data)
+                self._session_id = payload['sessionId']
+                break
+
+        self._sse_client = client
+
+    def call_tool(self, tool_name: str, params: dict) -> dict:
+        self._ensure_connected()
+        assert self._session_id and self._sse_client
+
+        request_id = int(time.time() * 1000)
+        payload = {
+            'jsonrpc': '2.0',
+            'method': 'tools/call',
+            'params': {'name': tool_name, 'arguments': params},
+            'id': request_id,
+        }
+
         headers = {
             'Content-Type': 'application/json',
-            'Accept': 'text/event-stream'
+            'X-Mcp-Session': self._session_id,
         }
         if self.token:
             headers['Authorization'] = f'Bearer {self.token}'
 
         response = requests.post(
-            f"{self.base_url}/mcp/sse",
-            json={
-                'jsonrpc': '2.0',
-                'method': 'tools/call',
-                'params': {'name': tool_name, 'arguments': params},
-                'id': 1
-            },
+            f"{self.base_url}/mcp/rpc",
+            params={'sessionId': self._session_id},
             headers=headers,
-            stream=True
+            json=payload,
+            timeout=30,
         )
+        response.raise_for_status()
 
-        client = sseclient.SSEClient(response)
-        for event in client.events():
-            if event.event == 'result':
-                return json.loads(event.data)['result']
-            elif event.event == 'error':
-                raise Exception(json.loads(event.data)['message'])
+        for event in self._sse_client.events():
+            body = json.loads(event.data)
+            if event.event == 'ack':
+                continue
+            if event.event == 'result' and body.get('id') == request_id:
+                return body['result']
+            if event.event == 'error' and body.get('id') == request_id:
+                raise RuntimeError(body['error']['message'])
+
+        raise RuntimeError('MCP server closed stream before responding')
+
 
 # Usage (anonymous dev mode)
 client = KoanMcpClient('http://localhost:5110')
@@ -678,17 +1140,22 @@ TOKEN=$(curl -X POST http://localhost:5110/.testoauth/token \
   -d "grant_type=client_credentials&client_id=mcp-client&client_secret=dev-secret" \
   | jq -r '.access_token')
 
-curl -X POST http://localhost:5110/mcp/sse \
-  -H "Authorization: Bearer $TOKEN" \
+# Terminal 1: establish SSE stream (observe `connected` event for sessionId)
+curl -N "http://localhost:5110/mcp/sse?access_token=$TOKEN" \
   -H "Accept: text/event-stream" \
+  -H "Authorization: Bearer $TOKEN"
+
+# Terminal 2: submit JSON-RPC call using sessionId from the connected event
+SESSION_ID="<value from connected event>"
+curl -X POST "http://localhost:5110/mcp/rpc?sessionId=$SESSION_ID" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Mcp-Session: $SESSION_ID" \
+  -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'
 
-# Response (SSE format):
-# event: result
-# data: {"jsonrpc":"2.0","id":1,"result":{"tools":[...]}}
-#
-# event: end
-# data: {"timestamp":"2025-09-24T12:34:56Z"}
+# Optional: discover capabilities over HTTP+SSE
+curl -s "http://localhost:5110/mcp/capabilities" \
+  -H "Authorization: Bearer $TOKEN" | jq
 ```
 
 ## Authentication & Security
@@ -727,13 +1194,14 @@ public bool RequireAuthentication
 
 ```csharp
 // Public entity - no auth
-[McpEntity(Name = "PublicData", RequireAuthentication = false)]
+[McpEntity(Name = "PublicData", RequireAuthentication = false, EnabledTransports = McpTransportMode.HttpSse)]
 public sealed class PublicData : Entity<PublicData> { }
 
 // Secure entity - auth required (overrides global)
 [McpEntity(
     Name = "SecureData",
     RequireAuthentication = true,
+    EnabledTransports = McpTransportMode.All,
     RequiredScopes = new[] { "admin:write" }
 )]
 public sealed class SecureData : Entity<SecureData> { }
@@ -749,8 +1217,8 @@ if (options.EnableCors && options.AllowedOrigins.Any())
     {
         policy.WithOrigins(options.AllowedOrigins)
               .AllowCredentials()
-              .WithHeaders("Authorization", "Content-Type")
-              .WithMethods("POST", "OPTIONS");
+              .WithHeaders("Authorization", "Content-Type", HttpSseHeaders.SessionId)
+              .WithMethods("GET", "POST", "OPTIONS");
     }));
 }
 ```
@@ -778,6 +1246,11 @@ if ((KoanEnv.IsProduction || KoanEnv.InContainer) && !httpContext.Request.IsHttp
 }
 ```
 
+**SSE Authentication Guidance:**
+- Prefer `Authorization` headers or authenticated cookies whenever possible. When browser-native `EventSource` cannot send headers, allow short-lived `access_token` query parameters only over HTTPS and with rate limiting enabled.
+- The transport rejects query-string tokens when HTTPS is not negotiated in production/container environments.
+- Clients should send both the `X-Mcp-Session` header and the `sessionId` query parameter when posting JSON-RPC payloads to accommodate caches and tracing.
+
 ### Security Warning System
 
 ```csharp
@@ -798,34 +1271,34 @@ if (!options.RequireAuthentication && (KoanEnv.IsProduction || KoanEnv.InContain
 
 **Priority: Critical**
 
-- [ ] Create `SseSessionManager` with concurrent session tracking
-- [ ] Create `SseSession` model (sessionId, user, stream, cancellation)
-- [ ] Implement `ISseTransportDispatcher` interface
-- [ ] Implement `SseTransportDispatcher` (JSON-RPC → SSE events)
-- [ ] Replace `HttpSseTransport` placeholder with full implementation
-- [ ] Add SSE event writer (`WriteSseEventAsync`)
-- [ ] Implement SSE header setup and connection lifecycle
+- [ ] Implement `HttpSseSessionManager` with concurrent session enforcement and heartbeat scheduling
+- [ ] Implement `HttpSseSession` channel pipeline (enqueue/dequeue, bridge attachment)
+- [ ] Create `ServerSentEvent` + `HttpSseHeaders` primitives
+- [ ] Implement `HttpSseRpcBridge` leveraging existing `IMcpTransportDispatcher`
+- [ ] Replace `HttpSseTransport` placeholder with GET `/sse` accept + POST `/rpc` submit flows
 
 **Deliverables:**
-- Working `/mcp/sse` endpoint
-- SSE event streaming
-- Multi-client session support
+- Working `/mcp/sse` stream endpoint
+- `/mcp/rpc` submission endpoint using StreamJsonRpc
+- Multi-client session support with connection limits
 
 ### Phase 2: Configuration & Registration (Week 2)
 
 **Priority: Critical**
 
-- [ ] Extend `McpServerOptions` with HTTP+SSE flags
+- [ ] Extend `McpServerOptions` with HTTP+SSE flags (`HttpSseRoute`, `PublishCapabilityEndpoint`)
 - [ ] Extend `McpTransportOptions` with SSE-specific settings
-- [ ] Update `ServiceCollectionExtensions.AddKoanMcp()` for HTTP+SSE
-- [ ] Create `EndpointExtensions.MapKoanMcpEndpoints()` method
-- [ ] Update `KoanWebStartupFilter` to auto-map endpoints
-- [ ] Add environment-aware authentication defaults
+- [ ] Update `McpEntityAttribute`/`McpEntityOverride` with `RequireAuthentication` + transport modes
+- [ ] Update `ServiceCollectionExtensions.AddKoanMcp()` for session manager hosted service + capability reporter
+- [ ] Create `EndpointExtensions.MapKoanMcpEndpoints()` mapping GET `/sse`, POST `/rpc`, GET `/capabilities`
+- [ ] Update `KoanWebStartupFilter` to reuse the existing endpoint routing block
+- [ ] Add environment-aware authentication defaults (production requires auth)
+- [ ] Update `KoanMcpAutoRegistrar` to include HTTP+SSE state in boot report
 
 **Deliverables:**
-- Configuration model complete
-- Auto-registration working
-- Endpoint mapping functional
+- Configuration model complete (options + overrides)
+- Auto-registration working with boot report coverage
+- Endpoint mapping functional across transports
 
 ### Phase 3: Authentication & Security (Week 3)
 
@@ -833,25 +1306,27 @@ if (!options.RequireAuthentication && (KoanEnv.IsProduction || KoanEnv.InContain
 
 - [ ] Integrate bearer token validation from `httpContext.User`
 - [ ] Implement scope enforcement (check `RequiredScopes`)
-- [ ] Add per-entity authentication overrides
-- [ ] Implement CORS configuration and middleware
+- [ ] Wire per-entity authentication overrides + transport filters
+- [ ] Implement CORS configuration allowing GET/POST + `X-Mcp-Session`
+- [ ] Enforce HTTPS for authenticated production requests
+- [ ] Add SSE authentication guidance + query-token guardrails
 - [ ] Add HTTP error responses (401, 403, 429, 500)
 - [ ] Add security warning system for insecure configs
 
 **Deliverables:**
 - Authentication working (bearer tokens, scopes)
-- CORS configured
+- CORS configured for SSE + RPC
 - Security warnings operational
 
 ### Phase 4: Monitoring & Diagnostics (Week 3)
 
 **Priority: Medium**
 
-- [ ] Implement health reporting (track active connections)
+- [ ] Implement health reporting (track active connections) via `IHealthAggregator`
 - [ ] Add SSE heartbeat loop (periodic keep-alive events)
-- [ ] Structured logging with session IDs
-- [ ] Error event streaming for MCP clients
-- [ ] Integration with existing Koan observability
+- [ ] Structured logging with session IDs + request IDs
+- [ ] Error/result/ack event streaming for MCP clients
+- [ ] Integration with existing Koan observability + boot report
 
 **Deliverables:**
 - Health metrics exposed
@@ -862,13 +1337,13 @@ if (!options.RequireAuthentication && (KoanEnv.IsProduction || KoanEnv.InContain
 
 **Priority: Medium**
 
-- [ ] Unit tests for `SseSessionManager` lifecycle
+- [ ] Unit tests for `HttpSseSessionManager` lifecycle (limits, heartbeats)
 - [ ] Integration tests for auth flow
-- [ ] Load testing (concurrent connections)
+- [ ] Load testing (concurrent connections + long-running sessions)
 - [ ] Security testing (invalid tokens, CORS violations)
-- [ ] Update S12.MedTrials sample with HTTP+SSE config
-- [ ] Write client SDK examples (TypeScript, Python)
-- [ ] Document security best practices
+- [ ] Update S12.MedTrials sample with HTTP+SSE config and capability endpoint
+- [ ] Write client SDK examples (TypeScript, Python) with GET/POST flow
+- [ ] Document security best practices and SSE auth guidance
 
 **Deliverables:**
 - Test coverage >80%
@@ -960,6 +1435,13 @@ data: {"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"TrialSite_List","descr
 ```
 event: error
 data: {"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"Invalid request"}}
+
+```
+
+### Acknowledgement Event
+```
+event: ack
+data: {"id":1}
 
 ```
 


### PR DESCRIPTION
## Summary
- restructure the proposal to describe a GET /mcp/sse handshake, POST /mcp/rpc submission path, and GET /mcp/capabilities discovery endpoint that align with common SSE practices
- document the shared StreamJsonRpc pipeline via HttpSseSessionManager, HttpSseRpcBridge, and ServerSentEvent primitives including ack/heartbeat behavior and health enforcement
- update configuration, capability reporting, client examples, and security guidance to match the revised transport flow

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_b_68d386e703d483289f11d286c2c92274