### PR TITLE
Add MCP console web client for S12 MedTrials

### DIFF
--- a/samples/S12.MedTrials.McpService/S12.MedTrials.McpService.csproj
+++ b/samples/S12.MedTrials.McpService/S12.MedTrials.McpService.csproj
@@ -32,4 +32,8 @@
     <ProjectReference Include="..\..\src\Koan.Web.Auth.TestProvider\Koan.Web.Auth.TestProvider.csproj" />
     <ProjectReference Include="..\..\src\Koan.Web.Auth.Services\Koan.Web.Auth.Services.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="wwwroot\\**\\*" CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
 </Project>

--- a/samples/S12.MedTrials.McpService/wwwroot/css/style.css
+++ b/samples/S12.MedTrials.McpService/wwwroot/css/style.css
@@ -1,0 +1,147 @@
+body {
+    background-color: #f8f9fc;
+}
+
+.navbar-brand {
+    font-weight: 600;
+    letter-spacing: 0.02em;
+}
+
+.badge.status-connected {
+    background-color: #198754;
+}
+
+.badge.status-connecting {
+    background-color: #ffc107;
+    color: #212529;
+}
+
+.badge.status-disconnected {
+    background-color: #dc3545;
+}
+
+.stat-card {
+    background-color: #ffffff;
+    border-radius: 0.6rem;
+    padding: 1.25rem;
+    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+    margin-bottom: 1.5rem;
+}
+
+.stat-card h5 {
+    font-size: 1.05rem;
+    margin-bottom: 0.5rem;
+}
+
+.stat-value {
+    font-size: 1.65rem;
+    font-weight: 600;
+}
+
+.stat-muted {
+    color: #6c757d;
+    font-size: 0.85rem;
+}
+
+.schema-json {
+    background-color: #0d1117;
+    color: #d2e2ff;
+    border-radius: 0.5rem;
+    padding: 1rem;
+    font-family: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-size: 0.85rem;
+    overflow: auto;
+}
+
+.tool-card {
+    border-radius: 0.75rem;
+    border: 1px solid #e1e4f2;
+    background-color: #ffffff;
+    box-shadow: 0 4px 20px rgba(15, 23, 42, 0.06);
+    margin-bottom: 1.5rem;
+}
+
+.tool-card .card-header {
+    background-color: transparent;
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.tool-card .card-body {
+    padding-top: 0.75rem;
+}
+
+.scope-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.65rem;
+    border-radius: 50rem;
+    background-color: rgba(13, 110, 253, 0.15);
+    color: #0d6efd;
+    font-size: 0.8rem;
+    margin-right: 0.5rem;
+    margin-bottom: 0.35rem;
+}
+
+.transport-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.3rem 0.6rem;
+    border-radius: 0.5rem;
+    background-color: rgba(25, 135, 84, 0.15);
+    color: #198754;
+    font-size: 0.8rem;
+    margin-right: 0.45rem;
+    margin-bottom: 0.35rem;
+}
+
+.timeline {
+    border-left: 2px solid #dee2e6;
+    padding-left: 1.5rem;
+    margin-left: 0.6rem;
+}
+
+.timeline-item {
+    position: relative;
+    margin-bottom: 1rem;
+}
+
+.timeline-item::before {
+    content: "";
+    position: absolute;
+    left: -1.75rem;
+    top: 0.4rem;
+    width: 0.85rem;
+    height: 0.85rem;
+    border-radius: 50%;
+    background-color: #0d6efd;
+}
+
+textarea.form-control {
+    min-height: 220px;
+    font-family: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
+pre.result-json {
+    background-color: #1b2433;
+    color: #e9f1ff;
+    padding: 1rem;
+    border-radius: 0.5rem;
+    font-size: 0.85rem;
+    overflow: auto;
+}
+
+.badge.bg-secondary {
+    font-size: 0.85rem;
+}
+
+.card-subtitle {
+    font-size: 0.85rem;
+    color: #6c757d;
+}
+
+.footer {
+    background-color: #f1f4f9;
+}

--- a/samples/S12.MedTrials.McpService/wwwroot/index.html
+++ b/samples/S12.MedTrials.McpService/wwwroot/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html ng-app="MedTrialsMcpApp">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="mcp-base-route" content="/mcp">
+    <title>S12 MedTrials MCP Console</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+    <link href="css/style.css" rel="stylesheet">
+</head>
+<body ng-controller="ShellController">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+        <div class="container">
+            <a class="navbar-brand" ng-href="#/overview">
+                <i class="fas fa-network-wired"></i> MCP Console
+            </a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navLinks">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navLinks">
+                <ul class="navbar-nav me-auto">
+                    <li class="nav-item"><a class="nav-link" ng-class="{ active: isActive('/overview') }" ng-href="#/overview">Overview</a></li>
+                    <li class="nav-item"><a class="nav-link" ng-class="{ active: isActive('/tools') }" ng-href="#/tools">Tools</a></li>
+                    <li class="nav-item"><a class="nav-link" ng-class="{ active: isActive('/explorer') }" ng-href="#/explorer">Explorer</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/swagger" target="_blank"><i class="fas fa-code"></i> API</a></li>
+                </ul>
+                <div class="d-flex align-items-center">
+                    <span class="badge" ng-class="statusBadgeClass(status.state)">
+                        <i class="fas fa-satellite-dish"></i>
+                        {{ status.state | uppercase }}
+                    </span>
+                    <span class="text-muted small ms-3" ng-if="status.sessionId">
+                        <i class="fas fa-id-badge"></i> {{ status.sessionId | limitTo: 12 }}
+                    </span>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <div class="container mt-4">
+        <div id="alert-area"></div>
+        <div ng-view></div>
+    </div>
+
+    <footer class="bg-light mt-5 py-4">
+        <div class="container">
+            <div class="row align-items-center">
+                <div class="col-md-4">
+                    <h6 class="text-uppercase">MCP Transport</h6>
+                    <p class="small text-muted mb-0">HTTP + SSE bridge exposing Koan tools for IDEs and agents.</p>
+                </div>
+                <div class="col-md-4">
+                    <ul class="list-unstyled small mb-0">
+                        <li><i class="fas fa-check text-success"></i> JSON-RPC 2.0 over resilient SSE sessions</li>
+                        <li><i class="fas fa-check text-success"></i> Capability document mirrors IDE discovery</li>
+                        <li><i class="fas fa-check text-success"></i> Tool explorer reuses live MCP executions</li>
+                    </ul>
+                </div>
+                <div class="col-md-4 text-md-end">
+                    <span class="badge bg-secondary"><i class="fas fa-flask"></i> S12 MedTrials Sample</span>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.8.3/angular.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.8.3/angular-route.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="js/app.js"></script>
+    <script src="js/mcp-client.js"></script>
+    <script src="js/controllers.js"></script>
+</body>
+</html>

--- a/samples/S12.MedTrials.McpService/wwwroot/js/app.js
+++ b/samples/S12.MedTrials.McpService/wwwroot/js/app.js
@@ -1,0 +1,68 @@
+(function () {
+    'use strict';
+
+    var app = angular.module('MedTrialsMcpApp', ['ngRoute']);
+
+    app.config(['$routeProvider', '$locationProvider', function ($routeProvider, $locationProvider) {
+        $routeProvider
+            .when('/overview', {
+                templateUrl: 'views/overview.html',
+                controller: 'OverviewController'
+            })
+            .when('/tools', {
+                templateUrl: 'views/tools.html',
+                controller: 'ToolsController'
+            })
+            .when('/explorer', {
+                templateUrl: 'views/explorer.html',
+                controller: 'ExplorerController'
+            })
+            .otherwise({ redirectTo: '/overview' });
+
+        $locationProvider.hashPrefix('');
+    }]);
+
+    app.run(['$rootScope', '$location', function ($rootScope, $location) {
+        $rootScope.isActive = function (path) {
+            return $location.path() === path;
+        };
+
+        $rootScope.showAlert = function (type, message) {
+            var alert = angular.element('<div class="alert alert-' + type + ' alert-dismissible fade show" role="alert"></div>');
+            alert.append(document.createTextNode(message));
+            alert.append('<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>');
+
+            var container = angular.element(document.querySelector('#alert-area'));
+            container.append(alert);
+
+            var alertInstance = null;
+            if (typeof bootstrap !== 'undefined' && bootstrap.Alert) {
+                alertInstance = bootstrap.Alert.getOrCreateInstance(alert[0]);
+            }
+
+            var closeAlert = function () {
+                if (!alert[0] || !alert[0].parentNode) {
+                    return;
+                }
+
+                try {
+                    if (alertInstance) {
+                        alertInstance.close();
+                    } else if (typeof alert.remove === 'function') {
+                        alert.remove();
+                    } else if (alert[0] && alert[0].parentNode) {
+                        alert[0].parentNode.removeChild(alert[0]);
+                    }
+                } catch (err) {
+                    if (typeof alert.remove === 'function') {
+                        alert.remove();
+                    } else if (alert[0] && alert[0].parentNode) {
+                        alert[0].parentNode.removeChild(alert[0]);
+                    }
+                }
+            };
+
+            setTimeout(closeAlert, 6000);
+        };
+    }]);
+})();

--- a/samples/S12.MedTrials.McpService/wwwroot/js/controllers.js
+++ b/samples/S12.MedTrials.McpService/wwwroot/js/controllers.js
@@ -1,0 +1,257 @@
+(function () {
+    'use strict';
+
+    angular.module('MedTrialsMcpApp')
+        .controller('ShellController', ['$scope', 'mcpClient', function ($scope, mcpClient) {
+            $scope.status = mcpClient.status;
+
+            $scope.statusBadgeClass = function (state) {
+                switch ((state || '').toLowerCase()) {
+                    case 'connected':
+                        return 'status-connected';
+                    case 'connecting':
+                        return 'status-connecting';
+                    default:
+                        return 'status-disconnected';
+                }
+            };
+
+            $scope.formatTimestamp = function (value) {
+                if (!value) {
+                    return '—';
+                }
+                return new Date(value).toLocaleString();
+            };
+        }])
+        .controller('OverviewController', ['$scope', 'mcpClient', function ($scope, mcpClient) {
+            $scope.loading = true;
+            $scope.capabilities = null;
+            $scope.transports = [];
+            $scope.tools = [];
+            $scope.error = null;
+
+            function load() {
+                $scope.loading = true;
+                mcpClient.getCapabilities()
+                    .then(function (document) {
+                        $scope.capabilities = document;
+                        $scope.transports = document.transports || [];
+                        $scope.tools = document.tools || [];
+                    })
+                    .catch(function (error) {
+                        console.error('Failed to load MCP capabilities', error);
+                        $scope.error = error;
+                        var message = (error && error.message) || 'Failed to load MCP capability document.';
+                        $scope.$root.showAlert('danger', message);
+                    })
+                    .finally(function () {
+                        $scope.loading = false;
+                    });
+            }
+
+            $scope.refresh = function () {
+                $scope.loading = true;
+                mcpClient.refreshCapabilities()
+                    .then(function (document) {
+                        $scope.capabilities = document;
+                        $scope.transports = document.transports || [];
+                        $scope.tools = document.tools || [];
+                        $scope.$root.showAlert('success', 'Capability document refreshed.');
+                    })
+                    .catch(function (error) {
+                        console.error('Failed to refresh MCP capabilities', error);
+                        var message = (error && error.message) || 'Capability refresh failed.';
+                        $scope.$root.showAlert('danger', message);
+                    })
+                    .finally(function () {
+                        $scope.loading = false;
+                    });
+            };
+
+            $scope.toolCount = function () {
+                return ($scope.tools || []).length;
+            };
+
+            $scope.securedToolCount = function () {
+                return ($scope.tools || []).filter(function (tool) { return tool.requireAuthentication; }).length;
+            };
+
+            $scope.primaryTransport = function () {
+                return ($scope.transports || [])[0] || null;
+            };
+
+            load();
+        }])
+        .controller('ToolsController', ['$scope', 'mcpClient', function ($scope, mcpClient) {
+            $scope.loading = true;
+            $scope.tools = [];
+            $scope.filterText = '';
+            $scope.expanded = {};
+
+            function loadTools(force) {
+                $scope.loading = true;
+                var loader = force ? mcpClient.refreshTools() : mcpClient.listTools();
+                loader.then(function (tools) {
+                    $scope.tools = tools || [];
+                }).catch(function (error) {
+                    console.error('Failed to load MCP tools', error);
+                    var message = (error && error.message) || 'Unable to load MCP tools.';
+                    $scope.$root.showAlert('danger', message);
+                }).finally(function () {
+                    $scope.loading = false;
+                });
+            }
+
+            $scope.toggleSchema = function (tool) {
+                if (!tool || !tool.name) {
+                    return;
+                }
+                $scope.expanded[tool.name] = !$scope.expanded[tool.name];
+            };
+
+            $scope.isSchemaVisible = function (tool) {
+                return tool && tool.name ? !!$scope.expanded[tool.name] : false;
+            };
+
+            $scope.filterPredicate = function (tool) {
+                if (!$scope.filterText) {
+                    return true;
+                }
+                var text = $scope.filterText.toLowerCase();
+                var nameMatch = tool.name && tool.name.toLowerCase().indexOf(text) !== -1;
+                var descriptionMatch = tool.description && tool.description.toLowerCase().indexOf(text) !== -1;
+                var entityMatch = tool.entity && tool.entity.toLowerCase().indexOf(text) !== -1;
+                return nameMatch || descriptionMatch || entityMatch;
+            };
+
+            $scope.refresh = function () {
+                loadTools(true);
+                $scope.$root.showAlert('info', 'Refreshing MCP tool catalogue…');
+            };
+
+            loadTools(false);
+        }])
+        .controller('ExplorerController', ['$scope', 'mcpClient', function ($scope, mcpClient) {
+            $scope.loading = false;
+            $scope.tools = [];
+            $scope.selectedTool = null;
+            $scope.argumentsJson = '{\n  \n}';
+            $scope.result = null;
+            $scope.resultJson = '';
+            $scope.headersJson = '';
+            $scope.diagnosticsJson = '';
+            $scope.warnings = [];
+            $scope.error = null;
+
+            function selectFirstTool(tools) {
+                if (!Array.isArray(tools) || tools.length === 0) {
+                    $scope.selectedTool = null;
+                    return;
+                }
+                $scope.selectedTool = tools[0];
+                $scope.argumentsJson = '{\n  \n}';
+            }
+
+            function loadTools() {
+                $scope.loading = true;
+                mcpClient.listTools()
+                    .then(function (tools) {
+                        $scope.tools = tools || [];
+                        if (!$scope.selectedTool && $scope.tools.length > 0) {
+                            selectFirstTool($scope.tools);
+                        }
+                    })
+                    .catch(function (error) {
+                        console.error('Failed to load tools for explorer', error);
+                        var message = (error && error.message) || 'Unable to load tools for explorer.';
+                        $scope.$root.showAlert('danger', message);
+                    })
+                    .finally(function () {
+                        $scope.loading = false;
+                    });
+            }
+
+            $scope.selectTool = function (toolName) {
+                if (!toolName) {
+                    $scope.selectedTool = null;
+                    return;
+                }
+                var match = ($scope.tools || []).find(function (tool) { return tool.name === toolName; });
+                $scope.selectedTool = match || null;
+                $scope.argumentsJson = '{\n  \n}';
+                $scope.result = null;
+                $scope.resultJson = '';
+                $scope.headersJson = '';
+                $scope.diagnosticsJson = '';
+                $scope.warnings = [];
+                $scope.error = null;
+            };
+
+            function parseArguments(text) {
+                if (!text) {
+                    return {};
+                }
+                var trimmed = text.trim();
+                if (!trimmed) {
+                    return {};
+                }
+                try {
+                    return JSON.parse(trimmed);
+                } catch (err) {
+                    throw new Error('Payload must be valid JSON.');
+                }
+            }
+
+            $scope.invoke = function () {
+                if (!$scope.selectedTool) {
+                    $scope.$root.showAlert('warning', 'Select a tool before invoking.');
+                    return;
+                }
+
+                var args;
+                try {
+                    args = parseArguments($scope.argumentsJson);
+                } catch (err) {
+                    $scope.$root.showAlert('danger', err.message || 'Invalid payload.');
+                    return;
+                }
+
+                $scope.loading = true;
+                $scope.result = null;
+                $scope.resultJson = '';
+                $scope.headersJson = '';
+                $scope.diagnosticsJson = '';
+                $scope.warnings = [];
+                $scope.error = null;
+
+                mcpClient.callTool($scope.selectedTool.name, args)
+                    .then(function (response) {
+                        $scope.result = response;
+                        $scope.resultJson = response && response.result ? JSON.stringify(response.result, null, 2) : '';
+                        $scope.headersJson = response && response.headers ? JSON.stringify(response.headers, null, 2) : '{}';
+                        $scope.diagnosticsJson = response && response.diagnostics ? JSON.stringify(response.diagnostics, null, 2) : '{}';
+                        $scope.warnings = response && Array.isArray(response.warnings) ? response.warnings : [];
+                        if (response && response.success) {
+                            $scope.$root.showAlert('success', 'Tool executed successfully.');
+                        } else {
+                            var warn = (response && response.errorMessage) ? response.errorMessage : 'Tool returned diagnostics. Review the response details.';
+                            $scope.$root.showAlert('warning', warn);
+                        }
+                    })
+                    .catch(function (error) {
+                        $scope.error = error;
+                        var message = (error && error.message) || 'Tool execution failed.';
+                        $scope.$root.showAlert('danger', message);
+                    })
+                    .finally(function () {
+                        $scope.loading = false;
+                    });
+            };
+
+            $scope.resetPayload = function () {
+                $scope.argumentsJson = '{\n  \n}';
+            };
+
+            loadTools();
+        }]);
+})();

--- a/samples/S12.MedTrials.McpService/wwwroot/js/mcp-client.js
+++ b/samples/S12.MedTrials.McpService/wwwroot/js/mcp-client.js
@@ -1,0 +1,505 @@
+(function () {
+    'use strict';
+
+    angular.module('MedTrialsMcpApp').factory('mcpClient', ['$http', '$q', '$timeout', '$rootScope', function ($http, $q, $timeout, $rootScope) {
+        var defaultRoute = '/mcp';
+        var baseMeta = document.querySelector('meta[name="mcp-base-route"]');
+        var baseRoute = (baseMeta && baseMeta.getAttribute('content')) ? baseMeta.getAttribute('content') : defaultRoute;
+        if (!baseRoute || typeof baseRoute !== 'string') {
+            baseRoute = defaultRoute;
+        }
+        baseRoute = baseRoute.trim();
+        if (!baseRoute.startsWith('/')) {
+            baseRoute = '/' + baseRoute;
+        }
+        if (baseRoute.length > 1 && baseRoute.endsWith('/')) {
+            baseRoute = baseRoute.slice(0, -1);
+        }
+
+        function makeUrl(segment) {
+            if (!segment) {
+                return baseRoute;
+            }
+            if (!segment.startsWith('/')) {
+                segment = '/' + segment;
+            }
+            return baseRoute + segment;
+        }
+
+        var eventSource = null;
+        var sessionId = null;
+        var connectionState = 'disconnected';
+        var reconnectTimer = null;
+        var reconnectAttempt = 0;
+        var waiters = [];
+        var pending = {};
+        var requestCounter = 0;
+        var cachedCapabilities = null;
+        var capabilitiesPromise = null;
+        var cachedTools = null;
+
+        var status = {
+            state: 'disconnected',
+            sessionId: null,
+            lastHeartbeat: null,
+            lastMessageAt: null,
+            connectedAt: null,
+            lastError: null,
+            reconnecting: false,
+            pendingRequests: 0,
+            transport: 'http+sse',
+            streamEndpoint: makeUrl('sse'),
+            rpcEndpoint: makeUrl('rpc'),
+            capabilityEndpoint: makeUrl('capabilities')
+        };
+
+        function applyStatus(mutator) {
+            $rootScope.$evalAsync(function () {
+                if (typeof mutator === 'function') {
+                    mutator(status);
+                }
+                status.sessionId = sessionId;
+                status.state = connectionState;
+                status.pendingRequests = Object.keys(pending).length;
+            });
+        }
+
+        function safeParse(json) {
+            if (!json) {
+                return null;
+            }
+            try {
+                return JSON.parse(json);
+            } catch (err) {
+                console.warn('Failed to parse MCP payload', err);
+                return null;
+            }
+        }
+
+        function resolveWaiters(value) {
+            if (waiters.length === 0) {
+                return;
+            }
+            waiters.forEach(function (deferred) {
+                deferred.resolve(value);
+            });
+            waiters = [];
+        }
+
+        function rejectWaiters(reason) {
+            if (waiters.length === 0) {
+                return;
+            }
+            waiters.forEach(function (deferred) {
+                deferred.reject(reason);
+            });
+            waiters = [];
+        }
+
+        function cleanupPending(id) {
+            var entry = pending[id];
+            if (!entry) {
+                return;
+            }
+            if (entry.timeout) {
+                $timeout.cancel(entry.timeout);
+            }
+            delete pending[id];
+            applyStatus();
+        }
+
+        function rejectPending(reason) {
+            Object.keys(pending).forEach(function (id) {
+                var entry = pending[id];
+                if (!entry) {
+                    return;
+                }
+                entry.deferred.reject({
+                    code: 'connection_lost',
+                    message: reason || 'MCP connection lost before the operation completed.'
+                });
+                cleanupPending(id);
+            });
+        }
+
+        function ensureConnected() {
+            if (connectionState === 'connected' && sessionId) {
+                return $q.resolve(sessionId);
+            }
+
+            var deferred = $q.defer();
+            waiters.push(deferred);
+
+            if (connectionState === 'disconnected') {
+                connect();
+            }
+
+            return deferred.promise;
+        }
+
+        function scheduleReconnect() {
+            if (reconnectTimer) {
+                return;
+            }
+
+            reconnectAttempt += 1;
+            var delay = Math.min(15000, Math.pow(2, reconnectAttempt) * 1000);
+            applyStatus(function (s) {
+                s.reconnecting = true;
+            });
+
+            reconnectTimer = $timeout(function () {
+                reconnectTimer = null;
+                connect();
+            }, delay);
+        }
+
+        function handleJsonRpc(message) {
+            if (!message || typeof message !== 'object') {
+                return;
+            }
+
+            var id = Object.prototype.hasOwnProperty.call(message, 'id') ? message.id : null;
+            applyStatus(function (s) {
+                s.lastMessageAt = new Date();
+            });
+
+            if (id === null || id === undefined) {
+                return;
+            }
+
+            var entry = pending[id];
+            if (!entry) {
+                return;
+            }
+
+            if (Object.prototype.hasOwnProperty.call(message, 'result')) {
+                entry.deferred.resolve(message.result);
+            } else if (Object.prototype.hasOwnProperty.call(message, 'error')) {
+                var err = message.error || {};
+                if (typeof err === 'string') {
+                    err = { code: 'error', message: err };
+                }
+                entry.deferred.reject(err);
+            } else {
+                entry.deferred.resolve(message);
+            }
+
+            cleanupPending(id);
+        }
+
+        function handleAck(event) {
+            var payload = safeParse(event.data);
+            if (!payload || !payload.id) {
+                return;
+            }
+            var entry = pending[payload.id];
+            if (entry) {
+                entry.acknowledged = new Date();
+            }
+        }
+
+        function handleHeartbeat(event) {
+            var payload = safeParse(event.data);
+            var timestamp = payload && payload.timestamp ? new Date(payload.timestamp) : new Date();
+            applyStatus(function (s) {
+                s.lastHeartbeat = timestamp;
+            });
+        }
+
+        function handleConnected(event) {
+            reconnectAttempt = 0;
+            var payload = safeParse(event.data) || {};
+            sessionId = payload.sessionId || null;
+            connectionState = sessionId ? 'connected' : 'connecting';
+            applyStatus(function (s) {
+                var connectedAt = payload.timestamp ? new Date(payload.timestamp) : new Date();
+                s.connectedAt = connectedAt;
+                s.lastHeartbeat = connectedAt;
+                s.reconnecting = false;
+                s.lastError = null;
+            });
+            if (sessionId) {
+                resolveWaiters(sessionId);
+            }
+        }
+
+        function handleServerError(event) {
+            if (event && typeof event.data === 'string' && event.data.length > 0) {
+                var payload = safeParse(event.data);
+                if (payload) {
+                    handleJsonRpc(payload);
+                }
+                return;
+            }
+            handleDisconnect('Server reported an error.');
+        }
+
+        function handleDisconnect(reason) {
+            if (eventSource) {
+                try { eventSource.close(); } catch (err) { /* ignore */ }
+                eventSource = null;
+            }
+
+            if (connectionState !== 'disconnected') {
+                connectionState = 'disconnected';
+                sessionId = null;
+                applyStatus(function (s) {
+                    s.lastError = reason || 'Connection closed.';
+                });
+            }
+
+            rejectPending(reason);
+            rejectWaiters(reason || 'Connection closed.');
+            scheduleReconnect();
+        }
+
+        function connect() {
+            if (eventSource) {
+                try { eventSource.close(); } catch (err) { /* ignore */ }
+                eventSource = null;
+            }
+            if (reconnectTimer) {
+                $timeout.cancel(reconnectTimer);
+                reconnectTimer = null;
+            }
+
+            connectionState = 'connecting';
+            applyStatus(function (s) {
+                s.reconnecting = false;
+            });
+
+            try {
+                eventSource = new EventSource(makeUrl('sse'), { withCredentials: true });
+            } catch (err) {
+                connectionState = 'disconnected';
+                applyStatus(function (s) {
+                    s.lastError = err && err.message ? err.message : 'Failed to open SSE stream.';
+                });
+                scheduleReconnect();
+                return;
+            }
+
+            eventSource.addEventListener('connected', handleConnected);
+            eventSource.addEventListener('heartbeat', handleHeartbeat);
+            eventSource.addEventListener('ack', handleAck);
+            eventSource.addEventListener('result', function (event) {
+                var payload = safeParse(event.data);
+                if (payload) {
+                    handleJsonRpc(payload);
+                }
+            });
+            eventSource.addEventListener('error', handleServerError);
+            eventSource.addEventListener('end', function (event) {
+                handleDisconnect('Stream completed.');
+            });
+            eventSource.onerror = function (event) {
+                if (event && typeof event.data === 'string' && event.data.length > 0) {
+                    handleServerError(event);
+                    return;
+                }
+                handleDisconnect('Connection error.');
+            };
+        }
+
+        function sendRpc(method, params) {
+            return ensureConnected().then(function () {
+                var id = (++requestCounter).toString();
+                var deferred = $q.defer();
+                var timeout = $timeout(function () {
+                    if (pending[id]) {
+                        pending[id].deferred.reject({
+                            code: 'timeout',
+                            message: 'MCP request timed out.'
+                        });
+                        cleanupPending(id);
+                    }
+                }, 30000);
+
+                pending[id] = {
+                    deferred: deferred,
+                    timeout: timeout
+                };
+                applyStatus();
+
+                var envelope = {
+                    jsonrpc: '2.0',
+                    id: id,
+                    method: method
+                };
+
+                if (params !== undefined) {
+                    envelope.params = params;
+                }
+
+                $http.post(makeUrl('rpc'), envelope, {
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-Mcp-Session': sessionId || ''
+                    }
+                }).catch(function (error) {
+                    cleanupPending(id);
+                    var payload = error && error.data ? error.data : { code: 'transport_error', message: 'Failed to submit MCP request.' };
+                    deferred.reject(payload);
+                });
+
+                return deferred.promise;
+            });
+        }
+
+        function normaliseCapabilities(data) {
+            var transports = [];
+            var tools = [];
+
+            if (data && Array.isArray(data.transports)) {
+                transports = data.transports.map(function (transport) {
+                    return {
+                        kind: transport.kind || transport.Kind || 'http+sse',
+                        streamEndpoint: transport.streamEndpoint || transport.StreamEndpoint || makeUrl('sse'),
+                        submitEndpoint: transport.submitEndpoint || transport.SubmitEndpoint || makeUrl('rpc'),
+                        capabilityEndpoint: transport.capabilityEndpoint || transport.CapabilityEndpoint || null,
+                        requireAuthentication: !!(transport.requireAuthentication || transport.RequireAuthentication)
+                    };
+                });
+            }
+
+            if (data && Array.isArray(data.tools)) {
+                tools = data.tools.map(function (tool) {
+                    return {
+                        name: tool.name || tool.Name,
+                        description: tool.description || tool.Description || '',
+                        requireAuthentication: !!(tool.requireAuthentication || tool.RequireAuthentication),
+                        enabledTransports: tool.enabledTransports || tool.EnabledTransports || null
+                    };
+                });
+            }
+
+            return {
+                version: (data && (data.version || data.Version)) || '2.0',
+                transports: transports,
+                tools: tools
+            };
+        }
+
+        function getCapabilities(forceRefresh) {
+            if (!forceRefresh && cachedCapabilities) {
+                return $q.resolve(cachedCapabilities);
+            }
+
+            if (!forceRefresh && capabilitiesPromise) {
+                return capabilitiesPromise;
+            }
+
+            capabilitiesPromise = $http.get(makeUrl('capabilities')).then(function (response) {
+                var document = normaliseCapabilities(response.data || {});
+                cachedCapabilities = document;
+                capabilitiesPromise = null;
+
+                if (document.transports.length > 0) {
+                    applyStatus(function (s) {
+                        var primary = document.transports[0];
+                        s.transport = primary.kind;
+                        s.streamEndpoint = primary.streamEndpoint;
+                        s.rpcEndpoint = primary.submitEndpoint;
+                        s.capabilityEndpoint = primary.capabilityEndpoint || makeUrl('capabilities');
+                    });
+                }
+
+                return document;
+            }).catch(function (error) {
+                capabilitiesPromise = null;
+                return $q.reject(error && error.data ? error.data : error);
+            });
+
+            return capabilitiesPromise;
+        }
+
+        function formatTool(tool) {
+            var metadata = tool.metadata || tool.Metadata || {};
+            var schema = tool.input_schema || tool.inputSchema || tool.InputSchema || {};
+            var requiredScopes = metadata.requiredScopes || metadata.RequiredScopes || [];
+            if (!Array.isArray(requiredScopes)) {
+                requiredScopes = [];
+            }
+
+            return {
+                name: tool.name,
+                description: tool.description || '',
+                schema: schema,
+                schemaJson: JSON.stringify(schema, null, 2),
+                metadata: metadata,
+                entity: metadata.entity || metadata.Entity || null,
+                operation: metadata.operation || metadata.Operation || null,
+                returnsCollection: !!(metadata.returnsCollection || metadata.ReturnsCollection),
+                isMutation: !!(metadata.isMutation || metadata.IsMutation),
+                requiredScopes: requiredScopes
+            };
+        }
+
+        function listTools(forceRefresh) {
+            if (!forceRefresh && cachedTools) {
+                return $q.resolve(cachedTools);
+            }
+
+            return sendRpc('tools/list').then(function (result) {
+                var list = (result && Array.isArray(result.tools)) ? result.tools : [];
+                cachedTools = list.map(formatTool);
+                return cachedTools;
+            });
+        }
+
+        function normaliseCallResult(result) {
+            if (!result || typeof result !== 'object') {
+                return {
+                    success: false,
+                    result: null,
+                    shortCircuit: null,
+                    headers: {},
+                    warnings: [],
+                    diagnostics: {},
+                    errorCode: 'invalid_response',
+                    errorMessage: 'MCP call returned no payload.'
+                };
+            }
+
+            return {
+                success: !!result.success,
+                result: result.result || null,
+                shortCircuit: result.short_circuit || result.shortCircuit || null,
+                headers: result.headers || {},
+                warnings: Array.isArray(result.warnings) ? result.warnings : [],
+                diagnostics: result.diagnostics || {},
+                errorCode: result.error_code || result.errorCode || null,
+                errorMessage: result.error_message || result.errorMessage || null
+            };
+        }
+
+        function callTool(name, args) {
+            if (!name) {
+                return $q.reject({ code: 'invalid_request', message: 'Tool name is required.' });
+            }
+
+            var parameters = { name: name };
+            if (args && typeof args === 'object' && Object.keys(args).length > 0) {
+                parameters.arguments = args;
+            }
+
+            return sendRpc('tools/call', parameters).then(function (result) {
+                return normaliseCallResult(result);
+            });
+        }
+
+        // Start the SSE connection eagerly.
+        connect();
+
+        return {
+            status: status,
+            getCapabilities: getCapabilities,
+            refreshCapabilities: function () { return getCapabilities(true); },
+            listTools: listTools,
+            refreshTools: function () { cachedTools = null; return listTools(true); },
+            callTool: callTool,
+            baseRoute: baseRoute
+        };
+    }]);
+})();

--- a/samples/S12.MedTrials.McpService/wwwroot/views/explorer.html
+++ b/samples/S12.MedTrials.McpService/wwwroot/views/explorer.html
@@ -1,0 +1,95 @@
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+        <h2 class="mb-0">Tool explorer</h2>
+        <p class="text-muted mb-0">Execute MCP tools over the active JSON-RPC session.</p>
+    </div>
+    <button type="button" class="btn btn-outline-primary" ng-click="resetPayload()" ng-disabled="loading">
+        <i class="fas fa-eraser"></i> Reset payload
+    </button>
+</div>
+
+<div class="card mb-4">
+    <div class="card-header">
+        <h5 class="mb-0">Invocation</h5>
+    </div>
+    <div class="card-body">
+        <div class="row g-3 mb-3">
+            <div class="col-md-6">
+                <label class="form-label">Tool</label>
+                <select class="form-select" ng-model="selectedTool" ng-options="tool as tool.name for tool in tools track by tool.name" ng-change="selectTool(selectedTool && selectedTool.name)" ng-disabled="loading || tools.length === 0">
+                    <option value="" disabled ng-if="!selectedTool">Select a tool</option>
+                </select>
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Metadata</label>
+                <div class="p-3 border rounded bg-light" ng-if="selectedTool">
+                    <div class="d-flex flex-wrap gap-2">
+                        <span class="scope-pill"><i class="fas fa-database"></i> {{ selectedTool.entity || 'Entity' }}</span>
+                        <span class="scope-pill"><i class="fas fa-bolt"></i> {{ selectedTool.operation || 'Operation' }}</span>
+                        <span class="scope-pill" ng-if="selectedTool.isMutation"><i class="fas fa-pen"></i> Mutation</span>
+                        <span class="scope-pill" ng-if="selectedTool.returnsCollection"><i class="fas fa-layer-group"></i> Collection</span>
+                    </div>
+                    <div class="mt-2" ng-if="selectedTool.requiredScopes.length > 0">
+                        <span class="scope-pill" ng-repeat="scope in selectedTool.requiredScopes"><i class="fas fa-lock"></i> {{ scope }}</span>
+                    </div>
+                </div>
+                <div class="text-muted small" ng-if="!selectedTool">Select a tool to view metadata.</div>
+            </div>
+        </div>
+
+        <label class="form-label">Arguments (JSON)</label>
+        <textarea class="form-control" ng-model="argumentsJson" ng-disabled="loading" spellcheck="false"></textarea>
+        <div class="mt-3">
+            <button type="button" class="btn btn-primary" ng-click="invoke()" ng-disabled="loading || !selectedTool">
+                <i class="fas fa-paper-plane"></i> Invoke tool
+            </button>
+            <button type="button" class="btn btn-link" ng-click="resetPayload()" ng-disabled="loading">
+                Reset
+            </button>
+        </div>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <h5 class="mb-0">Response</h5>
+        <span class="badge" ng-class="result && result.success ? 'bg-success' : 'bg-secondary'" ng-if="result">{{ result.success ? 'Success' : 'Diagnostics' }}</span>
+    </div>
+    <div class="card-body">
+        <div ng-if="loading" class="text-center my-4">
+            <div class="spinner-border text-primary" role="status"></div>
+            <p class="text-muted mt-3">Awaiting response from MCP transport…</p>
+        </div>
+        <div ng-if="!loading">
+            <div class="alert alert-danger" ng-if="error">
+                <strong>{{ error.code || 'error' }}:</strong> {{ error.message || 'Tool execution failed.' }}
+            </div>
+            <div ng-if="result">
+                <div class="row">
+                    <div class="col-lg-6">
+                        <h6>Result payload</h6>
+                        <pre class="result-json" ng-if="resultJson">{{ resultJson }}</pre>
+                        <p class="text-muted" ng-if="!resultJson">No payload returned.</p>
+                        <div class="mt-3" ng-if="warnings.length > 0">
+                            <h6><i class="fas fa-triangle-exclamation text-warning"></i> Warnings</h6>
+                            <ul class="text-warning small mb-0">
+                                <li ng-repeat="warning in warnings">{{ warning }}</li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="col-lg-6">
+                        <h6>Headers</h6>
+                        <pre class="result-json">{{ headersJson }}</pre>
+                        <h6 class="mt-3">Diagnostics</h6>
+                        <pre class="result-json">{{ diagnosticsJson }}</pre>
+                        <div class="mt-3" ng-if="result.shortCircuit">
+                            <h6>Short-circuit</h6>
+                            <pre class="result-json">{{ JSON.stringify(result.shortCircuit, null, 2) }}</pre>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div ng-if="!result && !error" class="text-muted">No invocation has been issued yet.</div>
+        </div>
+    </div>
+</div>

--- a/samples/S12.MedTrials.McpService/wwwroot/views/overview.html
+++ b/samples/S12.MedTrials.McpService/wwwroot/views/overview.html
@@ -1,0 +1,149 @@
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+        <h2 class="mb-0">MCP Transport Overview</h2>
+        <p class="text-muted mb-0">Live capability document sourced from the HTTP + SSE bridge.</p>
+    </div>
+    <button type="button" class="btn btn-outline-primary" ng-click="refresh()" ng-disabled="loading">
+        <i class="fas fa-rotate"></i> Refresh
+    </button>
+</div>
+
+<div ng-if="loading" class="text-center my-5">
+    <div class="spinner-border text-primary" role="status"></div>
+    <p class="text-muted mt-3">Loading capability document…</p>
+</div>
+
+<div ng-if="!loading && !capabilities" class="alert alert-warning">
+    Capability metadata is unavailable. Verify that the MCP transport publishes `/capabilities`.
+</div>
+
+<div ng-if="!loading && capabilities">
+    <div class="row">
+        <div class="col-md-4">
+            <div class="stat-card">
+                <h5><i class="fas fa-toolbox text-primary"></i> Tools online</h5>
+                <div class="stat-value">{{ toolCount() }}</div>
+                <div class="stat-muted">{{ securedToolCount() }} require authentication</div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="stat-card">
+                <h5><i class="fas fa-plug text-success"></i> Transports</h5>
+                <div class="stat-value">{{ transports.length || 0 }}</div>
+                <div class="stat-muted">Primary endpoint: <code>{{ (primaryTransport() && primaryTransport().streamEndpoint) || '—' }}</code></div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="stat-card">
+                <h5><i class="fas fa-shield-alt text-info"></i> Session state</h5>
+                <div class="stat-value text-capitalize">{{ status.state }}</div>
+                <div class="stat-muted">Last heartbeat: {{ formatTimestamp(status.lastHeartbeat) }}</div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card mb-4">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <div>
+                <h5 class="mb-0">Transport topology</h5>
+                <small class="text-muted">Endpoints surfaced to IDE or agent clients.</small>
+            </div>
+            <span class="badge bg-light text-dark">{{ capabilities.version }}</span>
+        </div>
+        <div class="card-body">
+            <div class="table-responsive">
+                <table class="table table-sm align-middle">
+                    <thead>
+                        <tr>
+                            <th scope="col">Transport</th>
+                            <th scope="col">Stream</th>
+                            <th scope="col">RPC Submit</th>
+                            <th scope="col">Capabilities</th>
+                            <th scope="col" class="text-center">Auth required</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr ng-repeat="transport in transports">
+                            <td>
+                                <span class="transport-pill"><i class="fas fa-satellite"></i> {{ transport.kind }}</span>
+                            </td>
+                            <td><code>{{ transport.streamEndpoint }}</code></td>
+                            <td><code>{{ transport.submitEndpoint }}</code></td>
+                            <td>
+                                <code ng-if="transport.capabilityEndpoint">{{ transport.capabilityEndpoint }}</code>
+                                <span ng-if="!transport.capabilityEndpoint" class="text-muted">—</span>
+                            </td>
+                            <td class="text-center">
+                                <i class="fas" ng-class="transport.requireAuthentication ? 'fa-lock text-danger' : 'fa-unlock text-success'"></i>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-lg-6">
+            <div class="card mb-4">
+                <div class="card-header">
+                    <h5 class="mb-0">Connection timeline</h5>
+                </div>
+                <div class="card-body">
+                    <div class="timeline">
+                        <div class="timeline-item">
+                            <h6>Session established</h6>
+                            <p class="text-muted mb-1">{{ formatTimestamp(status.connectedAt) }}</p>
+                            <small class="text-muted">Session ID {{ status.sessionId || '—' }}</small>
+                        </div>
+                        <div class="timeline-item">
+                            <h6>Last heartbeat</h6>
+                            <p class="text-muted mb-1">{{ formatTimestamp(status.lastHeartbeat) }}</p>
+                            <small class="text-muted">Maintained via server-sent events</small>
+                        </div>
+                        <div class="timeline-item">
+                            <h6>Last message</h6>
+                            <p class="text-muted mb-1">{{ formatTimestamp(status.lastMessageAt) }}</p>
+                            <small class="text-muted">Result or error streamed over SSE</small>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-lg-6">
+            <div class="card mb-4">
+                <div class="card-header">
+                    <h5 class="mb-0">Quick start</h5>
+                </div>
+                <div class="card-body">
+                    <p class="text-muted">Use the stream ID delivered during the <code>connected</code> event to submit JSON-RPC envelopes.</p>
+                    <pre class="schema-json mb-3">curl -N "{{ status.streamEndpoint }}" \
+  -H "Accept: text/event-stream"</pre>
+                    <pre class="schema-json">curl -s "{{ status.rpcEndpoint }}" \
+  -H "Content-Type: application/json" \
+  -H "X-Mcp-Session: &lt;session-id&gt;" \
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/list"}'</pre>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card mb-4">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <h5 class="mb-0">Registered tools</h5>
+            <span class="badge bg-primary bg-opacity-25 text-primary">{{ toolCount() }} available</span>
+        </div>
+        <div class="card-body">
+            <div class="row">
+                <div class="col-md-6 col-lg-4 mb-3" ng-repeat="tool in tools | limitTo:6">
+                    <div class="p-3 border rounded h-100">
+                        <h6 class="mb-1"><i class="fas fa-robot text-primary"></i> {{ tool.name }}</h6>
+                        <p class="text-muted small mb-2">{{ tool.description || 'No description provided.' }}</p>
+                        <span class="scope-pill" ng-if="tool.requireAuthentication"><i class="fas fa-lock"></i> Secured</span>
+                    </div>
+                </div>
+            </div>
+            <p class="text-muted small mb-0" ng-if="tools.length > 6">Open the <a ng-href="#/tools">tools catalogue</a> to inspect schemas and metadata.</p>
+        </div>
+    </div>
+</div>

--- a/samples/S12.MedTrials.McpService/wwwroot/views/tools.html
+++ b/samples/S12.MedTrials.McpService/wwwroot/views/tools.html
@@ -1,0 +1,66 @@
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+        <h2 class="mb-0">Tool catalogue</h2>
+        <p class="text-muted mb-0">Descriptor metadata sourced directly from <code>tools/list</code>.</p>
+    </div>
+    <button type="button" class="btn btn-outline-primary" ng-click="refresh()" ng-disabled="loading">
+        <i class="fas fa-sync"></i> Refresh
+    </button>
+</div>
+
+<div class="row mb-3">
+    <div class="col-md-6">
+        <label class="form-label text-muted">Filter tools</label>
+        <input type="text" class="form-control" placeholder="Search by name, entity, or description" ng-model="filterText">
+    </div>
+    <div class="col-md-6 d-flex align-items-end justify-content-md-end mt-3 mt-md-0">
+        <div class="text-muted small">
+            {{ (tools | filter:filterPredicate).length }} of {{ tools.length }} tools visible
+        </div>
+    </div>
+</div>
+
+<div ng-if="loading" class="text-center my-5">
+    <div class="spinner-border text-primary" role="status"></div>
+    <p class="text-muted mt-3">Discovering MCP tools…</p>
+</div>
+
+<div ng-if="!loading && tools.length === 0" class="alert alert-warning">
+    No tools were returned. Ensure entities are decorated with <code>McpEntityAttribute</code> and mutations are enabled when required.
+</div>
+
+<div class="tool-card card" ng-repeat="tool in tools | filter:filterPredicate">
+    <div class="card-header d-flex justify-content-between align-items-start">
+        <div>
+            <h5 class="mb-1">{{ tool.name }}</h5>
+            <div class="card-subtitle">{{ tool.entity || 'Unspecified entity' }} • {{ tool.operation || 'Operation' }}</div>
+        </div>
+        <div>
+            <span class="scope-pill" ng-if="tool.isMutation"><i class="fas fa-pen"></i> Mutation</span>
+            <span class="scope-pill" ng-if="tool.returnsCollection"><i class="fas fa-layer-group"></i> Collection</span>
+        </div>
+    </div>
+    <div class="card-body">
+        <p class="text-muted">{{ tool.description || 'No description available.' }}</p>
+        <div class="mb-2" ng-if="tool.requiredScopes.length > 0">
+            <span class="scope-pill" ng-repeat="scope in tool.requiredScopes"><i class="fas fa-lock"></i> {{ scope }}</span>
+        </div>
+        <dl class="row small mb-3">
+            <dt class="col-sm-3">Entity</dt>
+            <dd class="col-sm-9">{{ tool.entity || '—' }}</dd>
+            <dt class="col-sm-3">Operation</dt>
+            <dd class="col-sm-9">{{ tool.operation || '—' }}</dd>
+            <dt class="col-sm-3">Returns collection</dt>
+            <dd class="col-sm-9">{{ tool.returnsCollection ? 'Yes' : 'No' }}</dd>
+            <dt class="col-sm-3">Mutation</dt>
+            <dd class="col-sm-9">{{ tool.isMutation ? 'Yes' : 'No' }}</dd>
+        </dl>
+        <button type="button" class="btn btn-sm btn-outline-secondary" ng-click="toggleSchema(tool)">
+            <i class="fas" ng-class="isSchemaVisible(tool) ? 'fa-eye-slash' : 'fa-eye'"></i>
+            {{ isSchemaVisible(tool) ? 'Hide schema' : 'Show schema' }}
+        </button>
+        <div class="mt-3" ng-if="isSchemaVisible(tool)">
+            <pre class="schema-json">{{ tool.schemaJson }}</pre>
+        </div>
+    </div>
+</div>

--- a/samples/S12.MedTrials/README.md
+++ b/samples/S12.MedTrials/README.md
@@ -10,6 +10,7 @@ S12.MedTrials demonstrates how Koan's AI and MCP pillars combine to deliver an a
 - **AngularJS SPA** – Served from the API project's `wwwroot` with Bootstrap styling, route-based controllers, and Koan REST integrations.
 - **Seeded data** – A hosted worker seeds demo sites, visits, documents, and adverse events so the UI and APIs light up immediately after `dotnet run`.
 - **Dedicated MCP host** – `S12.MedTrials.McpService` runs as a standalone HTTP+SSE transport with zero-config development settings and a capability probe wired into the primary API.
+- **MCP console** – `S12.MedTrials.McpService/wwwroot` ships an AngularJS client to inspect capabilities, browse tool schemas, and execute JSON-RPC calls over the live session.
 
 ## Running the sample
 
@@ -49,6 +50,7 @@ The API listens on `http://localhost:5110` (see `AppManifest`). Swagger UI and t
 - Swagger: `http://localhost:5110/swagger`
 - SPA: `http://localhost:5110/index.html`
 - MCP HTTP+SSE: `http://localhost:5114/mcp`
+- MCP Console: `http://localhost:5114/index.html`
 
 **Note:** When running locally, ensure MongoDB, Weaviate, and Ollama are running separately on the ports configured in `appsettings.Development.json`.
 


### PR DESCRIPTION
## Summary
- add an Angular-based MCP console under `S12.MedTrials.McpService/wwwroot` with navigation, routing, and Bootstrap styling
- implement an SSE-aware MCP client service plus controllers/views to surface capability data, tool metadata, and an interactive tool explorer
- document the new console entry point in the S12 MedTrials README

## Testing
- `dotnet build samples/S12.MedTrials.McpService/S12.MedTrials.McpService.csproj` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d42754fe3083289cbf3490636b8939