### PR TITLE
Add DocMind insights, processing diagnostics, and model installation queue

### DIFF
--- a/samples/S13.DocMind/Controllers/InsightsController.cs
+++ b/samples/S13.DocMind/Controllers/InsightsController.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Mvc;
+using S13.DocMind.Services;
+
+namespace S13.DocMind.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class InsightsController : ControllerBase
+{
+    private readonly IDocumentInsightsService _insightsService;
+
+    public InsightsController(IDocumentInsightsService insightsService)
+    {
+        _insightsService = insightsService;
+    }
+
+    [HttpGet("overview")]
+    public async Task<ActionResult> GetOverview(CancellationToken cancellationToken)
+    {
+        var overview = await _insightsService.GetOverviewAsync(cancellationToken);
+        return Ok(overview);
+    }
+
+    [HttpGet("profiles/{profileId}")]
+    public async Task<ActionResult> GetProfileCollections(string profileId, CancellationToken cancellationToken)
+    {
+        var collections = await _insightsService.GetProfileCollectionsAsync(profileId, cancellationToken);
+        return Ok(collections);
+    }
+
+    [HttpGet("profiles")]
+    public Task<ActionResult> GetAllProfiles(CancellationToken cancellationToken)
+        => GetProfileCollections("all", cancellationToken);
+
+    [HttpGet("feeds")]
+    public async Task<ActionResult> GetFeeds(CancellationToken cancellationToken)
+    {
+        var feed = await _insightsService.GetAggregationFeedAsync(cancellationToken);
+        return Ok(feed);
+    }
+}

--- a/samples/S13.DocMind/Controllers/ModelsController.cs
+++ b/samples/S13.DocMind/Controllers/ModelsController.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using S13.DocMind.Services;
+
+namespace S13.DocMind.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ModelsController : ControllerBase
+{
+    private readonly IModelCatalogService _catalogService;
+    private readonly IModelInstallationQueue _installationQueue;
+
+    public ModelsController(IModelCatalogService catalogService, IModelInstallationQueue installationQueue)
+    {
+        _catalogService = catalogService;
+        _installationQueue = installationQueue;
+    }
+
+    [HttpGet("available")]
+    public async Task<ActionResult> GetAvailable(CancellationToken cancellationToken)
+    {
+        var models = await _catalogService.GetAvailableModelsAsync(cancellationToken);
+        return Ok(models);
+    }
+
+    [HttpGet("installed")]
+    public async Task<ActionResult> GetInstalled(CancellationToken cancellationToken)
+    {
+        var models = await _catalogService.GetInstalledModelsAsync(cancellationToken);
+        return Ok(models);
+    }
+
+    [HttpGet("search")]
+    public async Task<ActionResult> Search([FromQuery] string? query, [FromQuery] string? provider, CancellationToken cancellationToken)
+    {
+        var models = await _catalogService.SearchModelsAsync(query, provider, cancellationToken);
+        return Ok(models);
+    }
+
+    [HttpPost("{modelName}/install")]
+    public async Task<ActionResult> Install(string modelName, [FromBody] InstallModelRequest? request, CancellationToken cancellationToken)
+    {
+        var provider = string.IsNullOrEmpty(request?.Provider) ? "ollama" : request!.Provider!;
+        var available = await _catalogService.GetAvailableModelsAsync(cancellationToken);
+        var targetModel = available.FirstOrDefault(model =>
+            string.Equals(model.Name, modelName, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(model.Provider, provider, StringComparison.OrdinalIgnoreCase));
+
+        if (targetModel is null)
+        {
+            return NotFound(new { message = $"Model {modelName} for provider {provider} was not found" });
+        }
+
+        var status = await _installationQueue.EnqueueAsync(provider, modelName, cancellationToken);
+        var routeValues = new { installationId = status.InstallationId };
+        return AcceptedAtAction(nameof(GetInstallationStatus), routeValues, ModelInstallationStatusDto.From(status));
+    }
+
+    [HttpGet("installations")]
+    public ActionResult GetInstallations()
+    {
+        var statuses = _installationQueue.GetStatuses().Select(ModelInstallationStatusDto.From).ToList();
+        return Ok(statuses);
+    }
+
+    [HttpGet("installations/{installationId:guid}")]
+    public ActionResult GetInstallationStatus(Guid installationId)
+    {
+        var status = _installationQueue.GetStatus(installationId);
+        if (status is null)
+        {
+            return NotFound(new { message = "Installation not found" });
+        }
+
+        return Ok(ModelInstallationStatusDto.From(status));
+    }
+
+    [HttpGet("config")]
+    public async Task<ActionResult> GetConfiguration(CancellationToken cancellationToken)
+    {
+        var config = await _catalogService.GetConfigurationAsync(cancellationToken);
+        return Ok(config);
+    }
+
+    [HttpPut("text-model")]
+    public async Task<ActionResult> SetTextModel([FromBody] ModelSelectionRequest request, CancellationToken cancellationToken)
+    {
+        await _catalogService.SetDefaultModelAsync("text", request.ModelName, request.Provider, cancellationToken);
+        return NoContent();
+    }
+
+    [HttpPut("vision-model")]
+    public async Task<ActionResult> SetVisionModel([FromBody] ModelSelectionRequest request, CancellationToken cancellationToken)
+    {
+        await _catalogService.SetDefaultModelAsync("vision", request.ModelName, request.Provider, cancellationToken);
+        return NoContent();
+    }
+
+    [HttpGet("providers")]
+    public async Task<ActionResult> GetProviders(CancellationToken cancellationToken)
+    {
+        var providers = await _catalogService.GetProvidersAsync(cancellationToken);
+        return Ok(providers);
+    }
+
+    [HttpGet("health")]
+    public async Task<ActionResult> GetHealth(CancellationToken cancellationToken)
+    {
+        var health = await _catalogService.GetHealthAsync(cancellationToken);
+        return Ok(health);
+    }
+
+    [HttpGet("usage-stats")]
+    public async Task<ActionResult> GetUsage(CancellationToken cancellationToken)
+    {
+        var usage = await _catalogService.GetUsageAsync(cancellationToken);
+        return Ok(usage);
+    }
+}
+
+public class InstallModelRequest
+{
+    public string? Provider { get; set; }
+}
+
+public class ModelSelectionRequest
+{
+    public string ModelName { get; set; } = string.Empty;
+    public string Provider { get; set; } = string.Empty;
+}
+
+public record ModelInstallationStatusDto
+{
+    public Guid InstallationId { get; init; }
+    public string Provider { get; init; } = string.Empty;
+    public string ModelName { get; init; } = string.Empty;
+    public string State { get; init; } = string.Empty;
+    public int Progress { get; init; }
+    public string CurrentStep { get; init; } = string.Empty;
+    public DateTimeOffset EnqueuedAt { get; init; }
+    public DateTimeOffset? StartedAt { get; init; }
+    public DateTimeOffset? CompletedAt { get; init; }
+    public DateTimeOffset? LastUpdated { get; init; }
+    public string? ErrorMessage { get; init; }
+
+    public static ModelInstallationStatusDto From(ModelInstallationStatus status) => new()
+    {
+        InstallationId = status.InstallationId,
+        Provider = status.Provider,
+        ModelName = status.ModelName,
+        State = status.State.ToString().ToLowerInvariant(),
+        Progress = status.Progress,
+        CurrentStep = status.CurrentStep,
+        EnqueuedAt = status.EnqueuedAt,
+        StartedAt = status.StartedAt,
+        CompletedAt = status.CompletedAt,
+        LastUpdated = status.LastUpdated,
+        ErrorMessage = status.ErrorMessage
+    };
+}

--- a/samples/S13.DocMind/Controllers/ProcessingController.cs
+++ b/samples/S13.DocMind/Controllers/ProcessingController.cs
@@ -1,0 +1,63 @@
+using System;
+using Microsoft.AspNetCore.Mvc;
+using S13.DocMind.Services;
+
+namespace S13.DocMind.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ProcessingController : ControllerBase
+{
+    private readonly IDocumentProcessingDiagnostics _diagnostics;
+
+    public ProcessingController(IDocumentProcessingDiagnostics diagnostics)
+    {
+        _diagnostics = diagnostics;
+    }
+
+    [HttpGet("queue")]
+    public async Task<ActionResult> GetQueue(CancellationToken cancellationToken)
+    {
+        var queue = await _diagnostics.GetQueueAsync(cancellationToken);
+        return Ok(queue);
+    }
+
+    [HttpGet("timeline")]
+    public async Task<ActionResult> GetTimeline(
+        [FromQuery] string? documentTypeId,
+        [FromQuery] string? status,
+        [FromQuery] DateTime? from,
+        [FromQuery] DateTime? to,
+        CancellationToken cancellationToken = default)
+    {
+        var query = new ProcessingTimelineQuery
+        {
+            DocumentTypeId = documentTypeId,
+            Status = status,
+            FromDate = from,
+            ToDate = to
+        };
+
+        var timeline = await _diagnostics.GetTimelineAsync(query, cancellationToken);
+        return Ok(timeline);
+    }
+
+    [HttpPost("{fileId}/retry")]
+    public async Task<ActionResult> Retry(string fileId, [FromBody] ProcessingRetryRequest? request, CancellationToken cancellationToken)
+    {
+        var normalizedRequest = request ?? new ProcessingRetryRequest();
+        var result = await _diagnostics.RetryAsync(fileId, normalizedRequest, cancellationToken);
+        if (!result.Success)
+        {
+            return NotFound(new { message = result.Message });
+        }
+
+        return Ok(new
+        {
+            message = "Retry queued",
+            fileId = result.FileId,
+            fileStatus = result.FileStatus,
+            analysisStatus = result.AnalysisStatus
+        });
+    }
+}

--- a/samples/S13.DocMind/Program.cs
+++ b/samples/S13.DocMind/Program.cs
@@ -3,6 +3,7 @@ using Koan.Core.Modules;
 using Koan.Core.Observability;
 using Koan.Data.Core;
 using Koan.Web.Extensions;
+using S13.DocMind.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -13,6 +14,12 @@ builder.Services.AddKoan();
 builder.Services.AddKoanObservability();
 
 // Note: Service implementations are handled by Koan auto-registration
+builder.Services.AddSingleton<IDocumentAggregationService, DocumentAggregationService>();
+builder.Services.AddSingleton<IDocumentInsightsService, DocumentInsightsService>();
+builder.Services.AddSingleton<IDocumentProcessingDiagnostics, DocumentProcessingDiagnostics>();
+builder.Services.AddSingleton<IModelCatalogService, InMemoryModelCatalogService>();
+builder.Services.AddSingleton<IModelInstallationQueue, InMemoryModelInstallationQueue>();
+builder.Services.AddHostedService<ModelInstallationBackgroundService>();
 
 // Ensure required directories exist
 Directory.CreateDirectory(Path.Combine(builder.Environment.ContentRootPath, "uploads"));

--- a/samples/S13.DocMind/Services/DocumentInsightsService.cs
+++ b/samples/S13.DocMind/Services/DocumentInsightsService.cs
@@ -1,0 +1,273 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using S13.DocMind.Models;
+
+namespace S13.DocMind.Services;
+
+public interface IDocumentInsightsService
+{
+    Task<DocumentInsightsOverview> GetOverviewAsync(CancellationToken cancellationToken);
+    Task<IReadOnlyCollection<DocumentCollectionSummary>> GetProfileCollectionsAsync(string profileId, CancellationToken cancellationToken);
+    Task<IReadOnlyCollection<AggregationFeedItem>> GetAggregationFeedAsync(CancellationToken cancellationToken);
+}
+
+public interface IDocumentAggregationService
+{
+    Task<IReadOnlyCollection<AggregationFeedItem>> GetFeedAsync(CancellationToken cancellationToken);
+}
+
+public class DocumentInsightsService : IDocumentInsightsService
+{
+    private readonly IDocumentAggregationService _aggregationService;
+
+    public DocumentInsightsService(IDocumentAggregationService aggregationService)
+    {
+        _aggregationService = aggregationService;
+    }
+
+    public async Task<DocumentInsightsOverview> GetOverviewAsync(CancellationToken cancellationToken)
+    {
+        var files = await Models.File.All();
+        var analyses = await Analysis.All();
+        var documentTypes = await DocumentType.All();
+
+        var completedAnalyses = analyses.Where(a => a.Status == "completed").ToList();
+        var completedFiles = files.Where(f => f.Status == "completed").ToList();
+        var activeDocuments = files.Where(f => f.Status is "processing" or "analyzing").ToList();
+
+        var topDocumentTypes = files
+            .Where(f => !string.IsNullOrEmpty(f.DocumentTypeId))
+            .GroupBy(f => f.DocumentTypeId)
+            .Select(group =>
+            {
+                var documentType = documentTypes.FirstOrDefault(dt => dt.Id == group.Key);
+                return new DocumentTypeUsage
+                {
+                    DocumentTypeId = group.Key!,
+                    DocumentTypeName = documentType?.Name ?? group.Key!,
+                    UsageCount = group.Count(),
+                    LastUsed = group.Max(f => f.CompletedDate ?? f.AssignedDate ?? f.UploadDate)
+                };
+            })
+            .OrderByDescending(x => x.UsageCount)
+            .Take(5)
+            .ToList();
+
+        var overallConfidence = completedAnalyses.Count == 0
+            ? 0
+            : completedAnalyses.Average(a => a.OverallConfidence);
+
+        var processingRate = files.Count == 0
+            ? 0
+            : Math.Round(completedFiles.Count / (double)files.Count * 100, 1);
+
+        var insight = new DocumentInsightsOverview
+        {
+            TotalDocuments = files.Count,
+            CompletedDocuments = completedFiles.Count,
+            ActiveDocuments = activeDocuments.Count,
+            FailedDocuments = files.Count(f => f.Status == "failed"),
+            AverageConfidence = Math.Round(overallConfidence, 3),
+            AverageProcessingTimeMs = completedAnalyses
+                .Where(a => a.ProcessingTimeMs.HasValue)
+                .Select(a => a.ProcessingTimeMs!.Value)
+                .DefaultIfEmpty(0)
+                .Average(),
+            HighQualityDocumentCount = completedAnalyses.Count(a => a.IsHighQuality),
+            ReviewRequiredCount = completedAnalyses.Count(a => a.RequiresReview),
+            TopDocumentTypes = topDocumentTypes,
+            RecentDocuments = files
+                .OrderByDescending(f => f.CompletedDate ?? f.AssignedDate ?? f.UploadDate)
+                .Take(8)
+                .Select(f => new RecentDocumentInsight
+                {
+                    FileId = f.Id!,
+                    Name = f.Name,
+                    Status = f.Status,
+                    DocumentTypeId = f.DocumentTypeId,
+                    CompletedDate = f.CompletedDate ?? f.AssignedDate ?? f.UploadDate,
+                    Confidence = completedAnalyses
+                        .FirstOrDefault(a => a.Id == f.AnalysisId)?.OverallConfidence
+                })
+                .ToList()
+        };
+
+        return insight;
+    }
+
+    public async Task<IReadOnlyCollection<DocumentCollectionSummary>> GetProfileCollectionsAsync(string profileId, CancellationToken cancellationToken)
+    {
+        var files = await Models.File.All();
+        var analyses = await Analysis.All();
+        var documentTypes = await DocumentType.All();
+
+        var normalizedProfile = (profileId ?? string.Empty).Trim().ToLowerInvariant();
+        if (string.IsNullOrEmpty(normalizedProfile))
+        {
+            normalizedProfile = "all";
+        }
+
+        IEnumerable<IGrouping<string?, Models.File>> groupedFiles = normalizedProfile switch
+        {
+            "all" => files
+                .Where(f => !string.IsNullOrEmpty(f.DocumentTypeId))
+                .GroupBy(f => f.DocumentTypeId),
+            _ => files
+                .Where(f => string.Equals(
+                    documentTypes.FirstOrDefault(dt => dt.Id == f.DocumentTypeId)?.Category,
+                    normalizedProfile,
+                    StringComparison.OrdinalIgnoreCase))
+                .GroupBy(f => f.DocumentTypeId)
+        };
+
+        var summaries = groupedFiles
+            .Select(group =>
+            {
+                var documentType = documentTypes.FirstOrDefault(dt => dt.Id == group.Key);
+                var latestFiles = group
+                    .OrderByDescending(f => f.CompletedDate ?? f.AssignedDate ?? f.UploadDate)
+                    .Take(5)
+                    .Select(f => new CollectionDocumentSummary
+                    {
+                        FileId = f.Id!,
+                        Name = f.Name,
+                        Status = f.Status,
+                        CompletedDate = f.CompletedDate,
+                        AssignedDate = f.AssignedDate,
+                        UploadDate = f.UploadDate
+                    })
+                    .ToList();
+
+                var analysisConfidence = group
+                    .Select(file => analyses.FirstOrDefault(a => a.Id == file.AnalysisId))
+                    .Where(analysis => analysis != null && analysis.Status == "completed")
+                    .Select(analysis => analysis!.OverallConfidence)
+                    .DefaultIfEmpty(0)
+                    .Average();
+
+                return new DocumentCollectionSummary
+                {
+                    DocumentTypeId = group.Key ?? string.Empty,
+                    DocumentTypeName = documentType?.Name ?? group.Key ?? "Unknown",
+                    Category = documentType?.Category ?? normalizedProfile,
+                    DocumentCount = group.Count(),
+                    AverageConfidence = Math.Round(analysisConfidence, 3),
+                    LatestDocuments = latestFiles
+                };
+            })
+            .OrderByDescending(summary => summary.DocumentCount)
+            .ToList();
+
+        return summaries;
+    }
+
+    public Task<IReadOnlyCollection<AggregationFeedItem>> GetAggregationFeedAsync(CancellationToken cancellationToken)
+        => _aggregationService.GetFeedAsync(cancellationToken);
+}
+
+public class DocumentAggregationService : IDocumentAggregationService
+{
+    public async Task<IReadOnlyCollection<AggregationFeedItem>> GetFeedAsync(CancellationToken cancellationToken)
+    {
+        var files = await Models.File.All();
+        var analyses = await Analysis.All();
+        var documentTypes = await DocumentType.All();
+
+        var feed = files
+            .OrderByDescending(f => f.CompletedDate ?? f.AssignedDate ?? f.UploadDate)
+            .Take(20)
+            .Select(file =>
+            {
+                var documentType = documentTypes.FirstOrDefault(dt => dt.Id == file.DocumentTypeId);
+                var analysis = analyses.FirstOrDefault(a => a.Id == file.AnalysisId);
+                var summary = analysis?.ProcessingMetadata.TryGetValue("summary", out var summaryValue) == true
+                    ? summaryValue?.ToString()
+                    : null;
+                var highlights = analysis?.ProcessingMetadata.TryGetValue("highlights", out var highlightValue) == true
+                    ? highlightValue as IEnumerable<string> ?? Array.Empty<string>()
+                    : Array.Empty<string>();
+
+                return new AggregationFeedItem
+                {
+                    FileId = file.Id!,
+                    FileName = file.Name,
+                    Status = file.Status,
+                    DocumentTypeId = file.DocumentTypeId,
+                    DocumentTypeName = documentType?.Name,
+                    Confidence = analysis?.OverallConfidence,
+                    Summary = summary ?? $"{file.Name} is {file.Status}",
+                    LastUpdated = file.CompletedDate ?? file.AssignedDate ?? file.UploadDate,
+                    Highlights = highlights.ToList()
+                };
+            })
+            .ToList();
+
+        return feed;
+    }
+}
+
+public class DocumentInsightsOverview
+{
+    public int TotalDocuments { get; set; }
+    public int CompletedDocuments { get; set; }
+    public int ActiveDocuments { get; set; }
+    public int FailedDocuments { get; set; }
+    public double AverageConfidence { get; set; }
+    public double AverageProcessingTimeMs { get; set; }
+    public int HighQualityDocumentCount { get; set; }
+    public int ReviewRequiredCount { get; set; }
+    public IReadOnlyCollection<DocumentTypeUsage> TopDocumentTypes { get; set; } = Array.Empty<DocumentTypeUsage>();
+    public IReadOnlyCollection<RecentDocumentInsight> RecentDocuments { get; set; } = Array.Empty<RecentDocumentInsight>();
+}
+
+public class DocumentTypeUsage
+{
+    public string DocumentTypeId { get; set; } = string.Empty;
+    public string DocumentTypeName { get; set; } = string.Empty;
+    public int UsageCount { get; set; }
+    public DateTime? LastUsed { get; set; }
+}
+
+public class RecentDocumentInsight
+{
+    public string FileId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Status { get; set; } = string.Empty;
+    public string? DocumentTypeId { get; set; }
+    public DateTime? CompletedDate { get; set; }
+    public double? Confidence { get; set; }
+}
+
+public class DocumentCollectionSummary
+{
+    public string DocumentTypeId { get; set; } = string.Empty;
+    public string DocumentTypeName { get; set; } = string.Empty;
+    public string Category { get; set; } = string.Empty;
+    public int DocumentCount { get; set; }
+    public double AverageConfidence { get; set; }
+    public IReadOnlyCollection<CollectionDocumentSummary> LatestDocuments { get; set; } = Array.Empty<CollectionDocumentSummary>();
+}
+
+public class CollectionDocumentSummary
+{
+    public string FileId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Status { get; set; } = string.Empty;
+    public DateTime UploadDate { get; set; }
+    public DateTime? AssignedDate { get; set; }
+    public DateTime? CompletedDate { get; set; }
+}
+
+public class AggregationFeedItem
+{
+    public string FileId { get; set; } = string.Empty;
+    public string FileName { get; set; } = string.Empty;
+    public string Status { get; set; } = string.Empty;
+    public string? DocumentTypeId { get; set; }
+    public string? DocumentTypeName { get; set; }
+    public double? Confidence { get; set; }
+    public string Summary { get; set; } = string.Empty;
+    public DateTime LastUpdated { get; set; }
+    public IReadOnlyCollection<string> Highlights { get; set; } = Array.Empty<string>();
+}

--- a/samples/S13.DocMind/Services/ModelInstallationServices.cs
+++ b/samples/S13.DocMind/Services/ModelInstallationServices.cs
@@ -1,0 +1,348 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace S13.DocMind.Services;
+
+public interface IModelInstallationQueue
+{
+    Task<ModelInstallationStatus> EnqueueAsync(string provider, string modelName, CancellationToken cancellationToken);
+    IAsyncEnumerable<ModelInstallationStatus> DequeueAsync(CancellationToken cancellationToken);
+    IReadOnlyCollection<ModelInstallationStatus> GetStatuses();
+    ModelInstallationStatus? GetStatus(Guid installationId);
+}
+
+public class InMemoryModelInstallationQueue : IModelInstallationQueue
+{
+    private readonly Channel<ModelInstallationStatus> _channel;
+    private readonly ConcurrentDictionary<Guid, ModelInstallationStatus> _statuses = new();
+
+    public InMemoryModelInstallationQueue()
+    {
+        _channel = Channel.CreateUnbounded<ModelInstallationStatus>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            SingleWriter = false
+        });
+    }
+
+    public async Task<ModelInstallationStatus> EnqueueAsync(string provider, string modelName, CancellationToken cancellationToken)
+    {
+        var status = new ModelInstallationStatus
+        {
+            InstallationId = Guid.NewGuid(),
+            Provider = provider,
+            ModelName = modelName,
+            State = ModelInstallationState.Queued,
+            Progress = 0,
+            CurrentStep = "Queued",
+            EnqueuedAt = DateTimeOffset.UtcNow
+        };
+
+        _statuses[status.InstallationId] = status;
+        await _channel.Writer.WriteAsync(status, cancellationToken);
+        return status;
+    }
+
+    public async IAsyncEnumerable<ModelInstallationStatus> DequeueAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        while (await _channel.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            while (_channel.Reader.TryRead(out var status))
+            {
+                yield return status;
+            }
+        }
+    }
+
+    public IReadOnlyCollection<ModelInstallationStatus> GetStatuses()
+        => _statuses.Values
+            .OrderByDescending(status => status.EnqueuedAt)
+            .ToList();
+
+    public ModelInstallationStatus? GetStatus(Guid installationId)
+        => _statuses.TryGetValue(installationId, out var status) ? status : null;
+}
+
+public class ModelInstallationBackgroundService : BackgroundService
+{
+    private static readonly string[] InstallationSteps =
+    {
+        "Validating model", "Downloading model", "Optimizing weights", "Registering provider", "Finalizing"
+    };
+
+    private readonly IModelInstallationQueue _queue;
+    private readonly IModelCatalogService _catalogService;
+    private readonly ILogger<ModelInstallationBackgroundService> _logger;
+
+    public ModelInstallationBackgroundService(
+        IModelInstallationQueue queue,
+        IModelCatalogService catalogService,
+        ILogger<ModelInstallationBackgroundService> logger)
+    {
+        _queue = queue;
+        _catalogService = catalogService;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await foreach (var status in _queue.DequeueAsync(stoppingToken))
+        {
+            try
+            {
+                status.State = ModelInstallationState.Installing;
+                status.StartedAt = DateTimeOffset.UtcNow;
+
+                var stepProgress = 100 / InstallationSteps.Length;
+                for (var index = 0; index < InstallationSteps.Length; index++)
+                {
+                    stoppingToken.ThrowIfCancellationRequested();
+                    status.CurrentStep = InstallationSteps[index];
+                    status.Progress = Math.Min(95, (index + 1) * stepProgress);
+                    status.LastUpdated = DateTimeOffset.UtcNow;
+                    await Task.Delay(TimeSpan.FromMilliseconds(350), stoppingToken);
+                }
+
+                status.Progress = 100;
+                status.State = ModelInstallationState.Completed;
+                status.CompletedAt = DateTimeOffset.UtcNow;
+                status.LastUpdated = status.CompletedAt;
+                status.CurrentStep = "Completed";
+
+                await _catalogService.MarkInstalledAsync(status.Provider, status.ModelName, stoppingToken);
+                _logger.LogInformation("Model {ModelName} installed for provider {Provider}", status.ModelName, status.Provider);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                status.State = ModelInstallationState.Failed;
+                status.LastUpdated = DateTimeOffset.UtcNow;
+                status.ErrorMessage = ex.Message;
+                status.CurrentStep = "Failed";
+                _logger.LogError(ex, "Failed to install model {ModelName}", status.ModelName);
+            }
+        }
+    }
+}
+
+public interface IModelCatalogService
+{
+    Task<IReadOnlyCollection<ModelDescriptor>> GetAvailableModelsAsync(CancellationToken cancellationToken);
+    Task<IReadOnlyCollection<ModelDescriptor>> GetInstalledModelsAsync(CancellationToken cancellationToken);
+    Task<IReadOnlyCollection<ModelDescriptor>> SearchModelsAsync(string? query, string? provider, CancellationToken cancellationToken);
+    Task<ModelConfigurationSnapshot> GetConfigurationAsync(CancellationToken cancellationToken);
+    Task SetDefaultModelAsync(string kind, string modelName, string provider, CancellationToken cancellationToken);
+    Task<IReadOnlyCollection<ModelProviderStatus>> GetProvidersAsync(CancellationToken cancellationToken);
+    Task<ModelHealthReport> GetHealthAsync(CancellationToken cancellationToken);
+    Task<ModelUsageStatistics> GetUsageAsync(CancellationToken cancellationToken);
+    Task MarkInstalledAsync(string provider, string modelName, CancellationToken cancellationToken);
+}
+
+public class InMemoryModelCatalogService : IModelCatalogService
+{
+    private readonly List<ModelDescriptor> _availableModels = new()
+    {
+        new("gpt-4.1-mini", "openai", "OpenAI GPT-4.1 Mini", new[] { "text" }, "7B", false),
+        new("gpt-4o", "openai", "GPT-4 Omni", new[] { "text", "vision" }, "15B", true),
+        new("claude-3-5-sonnet", "anthropic", "Claude 3.5 Sonnet", new[] { "text", "analysis" }, "12B", false),
+        new("llama3.1:8b", "ollama", "Llama 3.1 8B", new[] { "text" }, "8B", false),
+        new("llava:13b", "ollama", "LLaVA 13B Vision", new[] { "vision", "text" }, "13B", true)
+    };
+
+    private readonly ConcurrentDictionary<string, ModelDescriptor> _installedModels = new(StringComparer.OrdinalIgnoreCase);
+
+    private readonly ConcurrentDictionary<string, string> _defaults = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["text"] = "gpt-4.1-mini|openai",
+        ["vision"] = "gpt-4o|openai"
+    };
+
+    public Task<IReadOnlyCollection<ModelDescriptor>> GetAvailableModelsAsync(CancellationToken cancellationToken)
+    {
+        var installedKeys = new HashSet<string>(_installedModels.Keys, StringComparer.OrdinalIgnoreCase);
+        var models = _availableModels
+            .Select(model =>
+            {
+                var key = $"{model.Provider}:{model.Name}";
+                return installedKeys.Contains(key)
+                    ? model with { IsInstalled = true }
+                    : model with { IsInstalled = false };
+            })
+            .ToList();
+
+        return Task.FromResult<IReadOnlyCollection<ModelDescriptor>>(models);
+    }
+
+    public Task<IReadOnlyCollection<ModelDescriptor>> GetInstalledModelsAsync(CancellationToken cancellationToken)
+        => Task.FromResult<IReadOnlyCollection<ModelDescriptor>>(_installedModels.Values.ToList());
+
+    public Task<IReadOnlyCollection<ModelDescriptor>> SearchModelsAsync(string? query, string? provider, CancellationToken cancellationToken)
+    {
+        var installedKeys = new HashSet<string>(_installedModels.Keys, StringComparer.OrdinalIgnoreCase);
+        var results = _availableModels.Where(model =>
+            (string.IsNullOrEmpty(query) || model.Name.Contains(query, StringComparison.OrdinalIgnoreCase) || model.DisplayName.Contains(query, StringComparison.OrdinalIgnoreCase)) &&
+            (string.IsNullOrEmpty(provider) || string.Equals(model.Provider, provider, StringComparison.OrdinalIgnoreCase)))
+            .Select(model =>
+            {
+                var key = $"{model.Provider}:{model.Name}";
+                return installedKeys.Contains(key)
+                    ? model with { IsInstalled = true }
+                    : model with { IsInstalled = false };
+            })
+            .ToList();
+
+        return Task.FromResult<IReadOnlyCollection<ModelDescriptor>>(results);
+    }
+
+    public Task<ModelConfigurationSnapshot> GetConfigurationAsync(CancellationToken cancellationToken)
+    {
+        var defaults = _defaults.ToDictionary(
+            pair => pair.Key,
+            pair =>
+            {
+                var components = pair.Value.Split('|');
+                return new ModelSelection
+                {
+                    ModelName = components[0],
+                    Provider = components.Length > 1 ? components[1] : string.Empty
+                };
+            },
+            StringComparer.OrdinalIgnoreCase);
+
+        var snapshot = new ModelConfigurationSnapshot
+        {
+            AvailableProviders = new[] { "openai", "ollama", "anthropic" },
+            Defaults = defaults
+        };
+
+        return Task.FromResult(snapshot);
+    }
+
+    public Task SetDefaultModelAsync(string kind, string modelName, string provider, CancellationToken cancellationToken)
+    {
+        _defaults[kind] = $"{modelName}|{provider}";
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyCollection<ModelProviderStatus>> GetProvidersAsync(CancellationToken cancellationToken)
+    {
+        var providers = new List<ModelProviderStatus>
+        {
+            new("openai", true, "Managed OpenAI provider"),
+            new("ollama", true, "Local Ollama runtime"),
+            new("anthropic", false, "Anthropic provider disabled"),
+        };
+
+        return Task.FromResult<IReadOnlyCollection<ModelProviderStatus>>(providers);
+    }
+
+    public Task<ModelHealthReport> GetHealthAsync(CancellationToken cancellationToken)
+    {
+        var report = new ModelHealthReport
+        {
+            HealthyProviders = new[] { "openai", "ollama" },
+            DegradedProviders = Array.Empty<string>(),
+            FailedProviders = new[] { "anthropic" }
+        };
+
+        return Task.FromResult(report);
+    }
+
+    public Task<ModelUsageStatistics> GetUsageAsync(CancellationToken cancellationToken)
+    {
+        var usage = new ModelUsageStatistics
+        {
+            TotalAnalyses = 128,
+            TotalTokens = 523_000,
+            ProviderUsage = new Dictionary<string, int>
+            {
+                ["openai"] = 84,
+                ["ollama"] = 32,
+                ["anthropic"] = 12
+            }
+        };
+
+        return Task.FromResult(usage);
+    }
+
+    public Task MarkInstalledAsync(string provider, string modelName, CancellationToken cancellationToken)
+    {
+        var descriptor = _availableModels.FirstOrDefault(model =>
+            string.Equals(model.Provider, provider, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(model.Name, modelName, StringComparison.OrdinalIgnoreCase));
+
+        if (descriptor is not null)
+        {
+            _installedModels[$"{provider}:{modelName}"] = descriptor with { IsInstalled = true };
+        }
+
+        return Task.CompletedTask;
+    }
+}
+
+public record ModelDescriptor(string Name, string Provider, string DisplayName, IReadOnlyCollection<string> Capabilities, string? Size, bool IsVisionCapable)
+{
+    public bool IsInstalled { get; init; }
+}
+
+public class ModelInstallationStatus
+{
+    public Guid InstallationId { get; set; }
+    public string Provider { get; set; } = string.Empty;
+    public string ModelName { get; set; } = string.Empty;
+    public ModelInstallationState State { get; set; }
+    public int Progress { get; set; }
+    public string CurrentStep { get; set; } = string.Empty;
+    public DateTimeOffset EnqueuedAt { get; set; }
+    public DateTimeOffset? StartedAt { get; set; }
+    public DateTimeOffset? CompletedAt { get; set; }
+    public DateTimeOffset? LastUpdated { get; set; }
+    public string? ErrorMessage { get; set; }
+}
+
+public enum ModelInstallationState
+{
+    Queued,
+    Installing,
+    Completed,
+    Failed
+}
+
+public class ModelConfigurationSnapshot
+{
+    public IReadOnlyCollection<string> AvailableProviders { get; set; } = Array.Empty<string>();
+    public IReadOnlyDictionary<string, ModelSelection> Defaults { get; set; } = new Dictionary<string, ModelSelection>();
+}
+
+public class ModelSelection
+{
+    public string ModelName { get; set; } = string.Empty;
+    public string Provider { get; set; } = string.Empty;
+}
+
+public record ModelProviderStatus(string Provider, bool Enabled, string Description);
+
+public class ModelHealthReport
+{
+    public IReadOnlyCollection<string> HealthyProviders { get; set; } = Array.Empty<string>();
+    public IReadOnlyCollection<string> DegradedProviders { get; set; } = Array.Empty<string>();
+    public IReadOnlyCollection<string> FailedProviders { get; set; } = Array.Empty<string>();
+}
+
+public class ModelUsageStatistics
+{
+    public int TotalAnalyses { get; set; }
+    public int TotalTokens { get; set; }
+    public IReadOnlyDictionary<string, int> ProviderUsage { get; set; } = new Dictionary<string, int>();
+}

--- a/samples/S13.DocMind/Services/ProcessingDiagnosticsService.cs
+++ b/samples/S13.DocMind/Services/ProcessingDiagnosticsService.cs
@@ -1,0 +1,258 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using S13.DocMind.Models;
+
+namespace S13.DocMind.Services;
+
+public interface IDocumentProcessingDiagnostics
+{
+    Task<IReadOnlyCollection<ProcessingQueueItem>> GetQueueAsync(CancellationToken cancellationToken);
+    Task<IReadOnlyCollection<ProcessingTimelineEntry>> GetTimelineAsync(ProcessingTimelineQuery query, CancellationToken cancellationToken);
+    Task<ProcessingRetryResult> RetryAsync(string fileId, ProcessingRetryRequest request, CancellationToken cancellationToken);
+}
+
+public class DocumentProcessingDiagnostics : IDocumentProcessingDiagnostics
+{
+    public async Task<IReadOnlyCollection<ProcessingQueueItem>> GetQueueAsync(CancellationToken cancellationToken)
+    {
+        var files = await Models.File.All();
+        var analyses = await Analysis.All();
+
+        var queueItems = files
+            .Where(file => file.Status is "uploaded" or "extracting" or "extracted" or "assigned" or "processing" or "analyzing")
+            .Select(file =>
+            {
+                var analysis = analyses.FirstOrDefault(a => a.Id == file.AnalysisId);
+
+                return new ProcessingQueueItem
+                {
+                    FileId = file.Id!,
+                    FileName = file.Name,
+                    Status = file.Status,
+                    DocumentTypeId = file.DocumentTypeId,
+                    AssignedDate = file.AssignedDate,
+                    UploadDate = file.UploadDate,
+                    CompletedDate = file.CompletedDate,
+                    ErrorMessage = file.ErrorMessage,
+                    AnalysisStatus = analysis?.Status,
+                    Confidence = analysis?.OverallConfidence,
+                    Progress = CalculateProgress(file.Status)
+                };
+            })
+            .OrderByDescending(item => item.UploadDate)
+            .ToList();
+
+        return queueItems;
+    }
+
+    public async Task<IReadOnlyCollection<ProcessingTimelineEntry>> GetTimelineAsync(ProcessingTimelineQuery query, CancellationToken cancellationToken)
+    {
+        var files = await Models.File.All();
+        var analyses = await Analysis.All();
+
+        var timeline = new List<ProcessingTimelineEntry>();
+
+        foreach (var file in files)
+        {
+            if (!string.IsNullOrEmpty(query.DocumentTypeId) && !string.Equals(file.DocumentTypeId, query.DocumentTypeId, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (query.FromDate.HasValue && file.UploadDate < query.FromDate.Value)
+            {
+                continue;
+            }
+
+            if (query.ToDate.HasValue && file.UploadDate > query.ToDate.Value)
+            {
+                continue;
+            }
+
+            var analysis = analyses.FirstOrDefault(a => a.Id == file.AnalysisId);
+
+            var steps = new List<ProcessingTimelineStep>
+            {
+                new("Uploaded", file.UploadDate, file.Status is "uploaded" ? ProcessingStepState.Current : ProcessingStepState.Completed)
+            };
+
+            if (file.ExtractedDate.HasValue)
+            {
+                steps.Add(new ProcessingTimelineStep("Extracted", file.ExtractedDate.Value, file.Status is "extracting" or "extracted" ? ProcessingStepState.Current : ProcessingStepState.Completed));
+            }
+
+            if (file.AssignedDate.HasValue)
+            {
+                steps.Add(new ProcessingTimelineStep("Type Assigned", file.AssignedDate.Value, file.Status is "assigned" ? ProcessingStepState.Current : ProcessingStepState.Completed));
+            }
+
+            if (analysis != null)
+            {
+                steps.Add(new ProcessingTimelineStep("Analysis Started", analysis.StartedDate, analysis.Status == "processing" ? ProcessingStepState.Current : ProcessingStepState.Completed));
+
+                if (analysis.CompletedDate.HasValue)
+                {
+                    steps.Add(new ProcessingTimelineStep("Analysis Completed", analysis.CompletedDate.Value, analysis.Status == "completed" ? ProcessingStepState.Completed : ProcessingStepState.Current));
+                }
+            }
+
+            if (file.CompletedDate.HasValue)
+            {
+                steps.Add(new ProcessingTimelineStep("Document Completed", file.CompletedDate.Value, file.Status == "completed" ? ProcessingStepState.Completed : ProcessingStepState.Current));
+            }
+
+            if (file.Status == "failed")
+            {
+                steps.Add(new ProcessingTimelineStep("Failed", file.LastErrorDate ?? file.CompletedDate ?? file.UploadDate, ProcessingStepState.Failed, file.ErrorMessage));
+            }
+
+            if (!string.IsNullOrEmpty(query.Status) && steps.All(step => !string.Equals(step.Name, query.Status, StringComparison.OrdinalIgnoreCase)))
+            {
+                continue;
+            }
+
+            timeline.Add(new ProcessingTimelineEntry
+            {
+                FileId = file.Id!,
+                FileName = file.Name,
+                DocumentTypeId = file.DocumentTypeId,
+                Steps = steps.OrderBy(step => step.Timestamp).ToList(),
+                CurrentStatus = file.Status,
+                Confidence = analysis?.OverallConfidence,
+                ErrorMessage = file.ErrorMessage
+            });
+        }
+
+        return timeline
+            .OrderByDescending(entry => entry.Steps.Max(step => step.Timestamp))
+            .ToList();
+    }
+
+    public async Task<ProcessingRetryResult> RetryAsync(string fileId, ProcessingRetryRequest request, CancellationToken cancellationToken)
+    {
+        var file = await Models.File.Get(fileId);
+        if (file is null)
+        {
+            return ProcessingRetryResult.NotFound(fileId);
+        }
+
+        var analysis = !string.IsNullOrEmpty(file.AnalysisId)
+            ? await Analysis.Get(file.AnalysisId)
+            : null;
+
+        if (request.ResetToStage is not null)
+        {
+            file.Status = request.ResetToStage;
+        }
+        else
+        {
+            file.Status = "uploaded";
+        }
+
+        file.ErrorMessage = null;
+        file.LastErrorDate = null;
+        file.CompletedDate = null;
+        file.AssignedDate = null;
+        file.ExtractedDate = null;
+
+        await file.Save(cancellationToken);
+
+        if (analysis != null && request.IncludeAnalysisReset)
+        {
+            analysis.Status = "processing";
+            analysis.CompletedDate = null;
+            analysis.ErrorMessage = null;
+            analysis.RetryCount++;
+            await analysis.Save(cancellationToken);
+        }
+
+        return ProcessingRetryResult.Success(file.Id!, file.Status, analysis?.Status);
+    }
+
+    private static int CalculateProgress(string status) => status switch
+    {
+        "uploaded" => 10,
+        "extracting" => 25,
+        "extracted" => 45,
+        "assigned" => 60,
+        "processing" => 75,
+        "analyzing" => 90,
+        "completed" => 100,
+        _ => 0
+    };
+}
+
+public record ProcessingTimelineQuery
+{
+    public string? DocumentTypeId { get; init; }
+    public string? Status { get; init; }
+    public DateTime? FromDate { get; init; }
+    public DateTime? ToDate { get; init; }
+}
+
+public class ProcessingTimelineEntry
+{
+    public string FileId { get; set; } = string.Empty;
+    public string FileName { get; set; } = string.Empty;
+    public string? DocumentTypeId { get; set; }
+    public string CurrentStatus { get; set; } = string.Empty;
+    public double? Confidence { get; set; }
+    public string? ErrorMessage { get; set; }
+    public IReadOnlyCollection<ProcessingTimelineStep> Steps { get; set; } = Array.Empty<ProcessingTimelineStep>();
+}
+
+public record ProcessingTimelineStep(string Name, DateTime Timestamp, ProcessingStepState State, string? Notes = null);
+
+public enum ProcessingStepState
+{
+    Pending,
+    Current,
+    Completed,
+    Failed
+}
+
+public class ProcessingQueueItem
+{
+    public string FileId { get; set; } = string.Empty;
+    public string FileName { get; set; } = string.Empty;
+    public string Status { get; set; } = string.Empty;
+    public string? DocumentTypeId { get; set; }
+    public DateTime UploadDate { get; set; }
+    public DateTime? AssignedDate { get; set; }
+    public DateTime? CompletedDate { get; set; }
+    public string? ErrorMessage { get; set; }
+    public string? AnalysisStatus { get; set; }
+    public double? Confidence { get; set; }
+    public int Progress { get; set; }
+}
+
+public class ProcessingRetryRequest
+{
+    public string? ResetToStage { get; set; }
+    public bool IncludeAnalysisReset { get; set; } = true;
+}
+
+public class ProcessingRetryResult
+{
+    private ProcessingRetryResult(bool success, string fileId, string? fileStatus, string? analysisStatus, string? message)
+    {
+        Success = success;
+        FileId = fileId;
+        FileStatus = fileStatus;
+        AnalysisStatus = analysisStatus;
+        Message = message;
+    }
+
+    public bool Success { get; }
+    public string FileId { get; }
+    public string? FileStatus { get; }
+    public string? AnalysisStatus { get; }
+    public string? Message { get; }
+
+    public static ProcessingRetryResult NotFound(string fileId)
+        => new(false, fileId, null, null, "File not found");
+
+    public static ProcessingRetryResult Success(string fileId, string? fileStatus, string? analysisStatus)
+        => new(true, fileId, fileStatus, analysisStatus, null);
+}

--- a/samples/S13.DocMind/wwwroot/app/services/fileService.js
+++ b/samples/S13.DocMind/wwwroot/app/services/fileService.js
@@ -41,6 +41,18 @@ angular.module('s13DocMindApp').service('FileService', ['ApiService', '$http', '
             return ApiService.get('/files/' + fileId + '/status');
         },
 
+        getProcessingQueue: function() {
+            return ApiService.get('/processing/queue');
+        },
+
+        getProcessingTimeline: function(params) {
+            return ApiService.get('/processing/timeline', params);
+        },
+
+        retryProcessing: function(fileId, options) {
+            return ApiService.post('/processing/' + fileId + '/retry', options || {});
+        },
+
         getAnalysis: function(fileId) {
             return ApiService.get('/files/' + fileId + '/analysis');
         },

--- a/samples/S13.DocMind/wwwroot/app/services/insightsService.js
+++ b/samples/S13.DocMind/wwwroot/app/services/insightsService.js
@@ -1,0 +1,18 @@
+angular.module('s13DocMindApp').service('InsightsService', ['ApiService', function(ApiService) {
+    return {
+        getOverview: function() {
+            return ApiService.get('/insights/overview');
+        },
+
+        getProfileCollections: function(profileId) {
+            if (!profileId) {
+                return ApiService.get('/insights/profiles');
+            }
+            return ApiService.get('/insights/profiles/' + encodeURIComponent(profileId));
+        },
+
+        getFeeds: function() {
+            return ApiService.get('/insights/feeds');
+        }
+    };
+}]);

--- a/samples/S13.DocMind/wwwroot/app/views/configuration/index.html
+++ b/samples/S13.DocMind/wwwroot/app/views/configuration/index.html
@@ -238,6 +238,53 @@
                     </div>
                 </div>
             </div>
+            <div class="card mb-4">
+                <div class="card-header">
+                    <div class="d-flex justify-content-between align-items-center">
+                        <h5 class="card-title mb-0"><i class="bi bi-cloud-download me-2"></i>Model Installations</h5>
+                        <button class="btn btn-outline-primary btn-sm" ng-click="refreshInstallations()">
+                            <i class="bi bi-arrow-repeat"></i> Refresh
+                        </button>
+                    </div>
+                </div>
+                <div class="card-body table-responsive">
+                    <table class="table align-middle mb-0">
+                        <thead>
+                            <tr>
+                                <th>Model</th>
+                                <th>Provider</th>
+                                <th>Status</th>
+                                <th>Progress</th>
+                                <th>Step</th>
+                                <th>Updated</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr ng-repeat="install in installations">
+                                <td>{{install.modelName}}</td>
+                                <td class="text-uppercase">{{install.provider}}</td>
+                                <td>
+                                    <span class="badge" ng-class="{
+                                        'bg-success': install.state === 'completed',
+                                        'bg-warning text-dark': install.state === 'installing' || install.state === 'queued',
+                                        'bg-danger': install.state === 'failed'
+                                    }">{{install.state | uppercase}}</span>
+                                </td>
+                                <td>
+                                    <div class="progress" style="height: 6px;">
+                                        <div class="progress-bar" role="progressbar" style="width: {{install.progress}}%" aria-valuemin="0" aria-valuemax="100"></div>
+                                    </div>
+                                </td>
+                                <td>{{install.currentStep}}</td>
+                                <td>{{(install.lastUpdated || install.enqueuedAt) | date:'short'}}</td>
+                            </tr>
+                            <tr ng-if="installations.length === 0">
+                                <td colspan="6" class="text-center text-muted py-3">No model installations yet</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
         </div>
 
         <!-- Data Storage Configuration -->

--- a/samples/S13.DocMind/wwwroot/app/views/dashboard/index.html
+++ b/samples/S13.DocMind/wwwroot/app/views/dashboard/index.html
@@ -1,106 +1,134 @@
 <div class="container-fluid py-4">
-    <div class="row">
+    <div class="row" ng-if="loading">
+        <div class="col-12 text-center py-5">
+            <div class="spinner-border text-primary" role="status"></div>
+            <p class="text-muted mt-3">Loading insights...</p>
+        </div>
+    </div>
+
+    <div class="row" ng-if="!loading">
         <div class="col-12">
             <h1 class="h3 mb-4">Dashboard</h1>
 
-            <!-- Stats Cards -->
             <div class="row mb-4">
-                <div class="col-md-3">
-                    <div class="card bg-primary text-white">
+                <div class="col-md-3 mb-3">
+                    <div class="card bg-primary text-white h-100">
                         <div class="card-body">
-                            <div class="d-flex justify-content-between">
-                                <div>
-                                    <h5 class="card-title">Total Files</h5>
-                                    <h2>{{stats.totalFiles || 0}}</h2>
+                            <h5 class="card-title">Total Documents</h5>
+                            <h2 class="mb-0">{{overview.totalDocuments || 0}}</h2>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-3 mb-3">
+                    <div class="card bg-success text-white h-100">
+                        <div class="card-body">
+                            <h5 class="card-title">Completed</h5>
+                            <h2 class="mb-0">{{overview.completedDocuments || 0}}</h2>
+                            <small class="opacity-75">{{getCompletionRate()}}% completion</small>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-3 mb-3">
+                    <div class="card bg-warning text-white h-100">
+                        <div class="card-body">
+                            <h5 class="card-title">In Flight</h5>
+                            <h2 class="mb-0">{{overview.activeDocuments || 0}}</h2>
+                            <small class="opacity-75">{{overview.failedDocuments || 0}} failed</small>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-3 mb-3">
+                    <div class="card bg-info text-white h-100">
+                        <div class="card-body">
+                            <h5 class="card-title">Avg Confidence</h5>
+                            <h2 class="mb-0">{{(overview.averageConfidence * 100) | number:0}}%</h2>
+                            <small class="opacity-75">{{overview.highQualityDocumentCount || 0}} high quality</small>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="row">
+                <div class="col-lg-7 mb-4">
+                    <div class="card h-100">
+                        <div class="card-header">
+                            <h5 class="card-title mb-0">Activity Feed</h5>
+                        </div>
+                        <div class="card-body">
+                            <div ng-if="activityFeed.length === 0" class="text-center py-4">
+                                <i class="bi bi-activity" style="font-size: 3rem; opacity: 0.3;"></i>
+                                <p class="text-muted mt-2">No recent activity available</p>
+                            </div>
+                            <div ng-repeat="item in activityFeed" class="mb-3">
+                                <div class="d-flex justify-content-between align-items-start">
+                                    <div>
+                                        <h6 class="mb-1">{{item.fileName}}</h6>
+                                        <p class="mb-1 text-muted">{{item.summary}}</p>
+                                        <div class="small text-muted">{{formatTimestamp(item.lastUpdated) | date:'medium'}}</div>
+                                    </div>
+                                    <span class="badge" ng-class="{'bg-success': item.status === 'completed', 'bg-warning': item.status !== 'completed'}">{{item.status | uppercase}}</span>
                                 </div>
-                                <i class="bi bi-files" style="font-size: 2rem; opacity: 0.7;"></i>
                             </div>
                         </div>
                     </div>
                 </div>
-                <div class="col-md-3">
-                    <div class="card bg-success text-white">
-                        <div class="card-body">
-                            <div class="d-flex justify-content-between">
-                                <div>
-                                    <h5 class="card-title">Processed</h5>
-                                    <h2>{{stats.processedFiles || 0}}</h2>
-                                </div>
-                                <i class="bi bi-check-circle" style="font-size: 2rem; opacity: 0.7;"></i>
-                            </div>
+
+                <div class="col-lg-5 mb-4">
+                    <div class="card h-100">
+                        <div class="card-header">
+                            <h5 class="card-title mb-0">Top Collections</h5>
                         </div>
-                    </div>
-                </div>
-                <div class="col-md-3">
-                    <div class="card bg-warning text-white">
                         <div class="card-body">
-                            <div class="d-flex justify-content-between">
-                                <div>
-                                    <h5 class="card-title">Processing</h5>
-                                    <h2>{{stats.processingFiles || 0}}</h2>
-                                </div>
-                                <i class="bi bi-hourglass-split" style="font-size: 2rem; opacity: 0.7;"></i>
+                            <div ng-if="getTopCollections().length === 0" class="text-center py-4 text-muted">
+                                No profile collections available yet.
                             </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="col-md-3">
-                    <div class="card bg-info text-white">
-                        <div class="card-body">
-                            <div class="d-flex justify-content-between">
-                                <div>
-                                    <h5 class="card-title">Document Types</h5>
-                                    <h2>{{stats.documentTypes || 0}}</h2>
+                            <div ng-repeat="collection in getTopCollections()" class="mb-4">
+                                <div class="d-flex justify-content-between align-items-center">
+                                    <div>
+                                        <h6 class="mb-1">{{collection.documentTypeName}}</h6>
+                                        <small class="text-muted">{{collection.documentCount}} documents • Avg confidence {{(collection.averageConfidence * 100) | number:0}}%</small>
+                                    </div>
+                                    <span class="badge bg-secondary">{{collection.category || 'general'}}</span>
                                 </div>
-                                <i class="bi bi-collection" style="font-size: 2rem; opacity: 0.7;"></i>
+                                <ul class="list-unstyled mt-2 mb-0">
+                                    <li ng-repeat="doc in collection.latestDocuments" class="small text-muted">
+                                        {{doc.name}} · {{formatTimestamp(doc.completedDate || doc.assignedDate || doc.uploadDate) | date:'short'}}
+                                    </li>
+                                </ul>
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
 
-            <!-- Recent Activity -->
-            <div class="row">
-                <div class="col-md-8">
-                    <div class="card">
-                        <div class="card-header">
-                            <h5 class="card-title mb-0">Recent Activity</h5>
-                        </div>
-                        <div class="card-body">
-                            <div ng-show="recentActivity.length === 0" class="text-center py-4">
-                                <i class="bi bi-activity" style="font-size: 3rem; opacity: 0.3;"></i>
-                                <p class="text-muted mt-2">No recent activity</p>
-                            </div>
-                            <div ng-repeat="activity in recentActivity" class="d-flex align-items-center mb-3">
-                                <i class="bi bi-circle-fill text-primary me-3" style="font-size: 0.5rem;"></i>
-                                <div class="flex-grow-1">
-                                    <div class="fw-medium">{{activity.description}}</div>
-                                    <small class="text-muted">{{activity.timestamp | date:'medium'}}</small>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="card-title mb-0">Recent Documents</h5>
                 </div>
-
-                <div class="col-md-4">
-                    <div class="card">
-                        <div class="card-header">
-                            <h5 class="card-title mb-0">Quick Actions</h5>
-                        </div>
-                        <div class="card-body">
-                            <div class="d-grid gap-2">
-                                <a href="#/files/upload" class="btn btn-primary">
-                                    <i class="bi bi-upload"></i> Upload Files
-                                </a>
-                                <a href="#/document-types/new" class="btn btn-outline-primary">
-                                    <i class="bi bi-plus-circle"></i> New Document Type
-                                </a>
-                                <a href="#/analysis" class="btn btn-outline-secondary">
-                                    <i class="bi bi-graph-up"></i> View Analysis
-                                </a>
-                            </div>
-                        </div>
-                    </div>
+                <div class="card-body table-responsive">
+                    <table class="table align-middle">
+                        <thead>
+                            <tr>
+                                <th>Name</th>
+                                <th>Status</th>
+                                <th>Type</th>
+                                <th>Completed</th>
+                                <th>Confidence</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr ng-repeat="doc in (overview.recentDocuments || [])">
+                                <td>{{doc.name}}</td>
+                                <td>{{doc.status | uppercase}}</td>
+                                <td>{{doc.documentTypeId || 'Unassigned'}}</td>
+                                <td>{{doc.completedDate | date:'medium'}}</td>
+                                <td>{{(doc.confidence * 100) | number:0}}%</td>
+                            </tr>
+                            <tr ng-if="(overview.recentDocuments || []).length === 0">
+                                <td colspan="5" class="text-center text-muted">No recent documents</td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </div>

--- a/samples/S13.DocMind/wwwroot/index.html
+++ b/samples/S13.DocMind/wwwroot/index.html
@@ -147,6 +147,7 @@
     <script src="app/services/fileService.js"></script>
     <script src="app/services/documentTypeService.js"></script>
     <script src="app/services/analysisService.js"></script>
+    <script src="app/services/insightsService.js"></script>
     <script src="app/services/configurationService.js"></script>
     <script src="app/services/toastService.js"></script>
 

--- a/samples/S13.DocMind/wwwroot/openapi.json
+++ b/samples/S13.DocMind/wwwroot/openapi.json
@@ -1,0 +1,399 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "S13.DocMind API",
+    "version": "1.0.0",
+    "description": "API surface for document insights, processing diagnostics, and model management."
+  },
+  "paths": {
+    "/api/insights/overview": {
+      "get": {
+        "summary": "Retrieve high level document insights",
+        "operationId": "getInsightsOverview",
+        "responses": {
+          "200": {
+            "description": "Overview metrics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentInsightsOverview"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/insights/profiles/{profileId}": {
+      "get": {
+        "summary": "Get profile collection summaries",
+        "operationId": "getInsightsProfile",
+        "parameters": [
+          {
+            "name": "profileId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Collection summaries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DocumentCollectionSummary"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/insights/feeds": {
+      "get": {
+        "summary": "Get aggregation feed items",
+        "operationId": "getInsightsFeeds",
+        "responses": {
+          "200": {
+            "description": "Feed entries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AggregationFeedItem"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/processing/queue": {
+      "get": {
+        "summary": "Get processing queue diagnostics",
+        "operationId": "getProcessingQueue",
+        "responses": {
+          "200": {
+            "description": "Queue items",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/ProcessingQueueItem" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/processing/timeline": {
+      "get": {
+        "summary": "Get processing timelines",
+        "operationId": "getProcessingTimeline",
+        "parameters": [
+          { "name": "documentTypeId", "in": "query", "schema": { "type": "string" } },
+          { "name": "status", "in": "query", "schema": { "type": "string" } },
+          { "name": "from", "in": "query", "schema": { "type": "string", "format": "date-time" } },
+          { "name": "to", "in": "query", "schema": { "type": "string", "format": "date-time" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Timeline entries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/ProcessingTimelineEntry" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/processing/{fileId}/retry": {
+      "post": {
+        "summary": "Retry a document in the processing pipeline",
+        "operationId": "postProcessingRetry",
+        "parameters": [
+          {
+            "name": "fileId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ProcessingRetryRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Retry accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "fileId": { "type": "string" },
+                    "fileStatus": { "type": "string" },
+                    "analysisStatus": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "File not found"
+          }
+        }
+      }
+    },
+    "/api/models/available": {
+      "get": {
+        "summary": "Get available models",
+        "operationId": "getModelsAvailable",
+        "responses": {
+          "200": {
+            "description": "Available models",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/ModelDescriptor" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/models/{modelName}/install": {
+      "post": {
+        "summary": "Queue model installation",
+        "operationId": "postModelInstall",
+        "parameters": [
+          { "name": "modelName", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/InstallModelRequest" }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Installation queued",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ModelInstallationStatus" }
+              }
+            }
+          },
+          "404": { "description": "Model not found" }
+        }
+      }
+    },
+    "/api/models/installations": {
+      "get": {
+        "summary": "List model installation statuses",
+        "operationId": "getModelInstallations",
+        "responses": {
+          "200": {
+            "description": "Installation statuses",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/ModelInstallationStatus" }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "DocumentInsightsOverview": {
+        "type": "object",
+        "properties": {
+          "totalDocuments": { "type": "integer" },
+          "completedDocuments": { "type": "integer" },
+          "activeDocuments": { "type": "integer" },
+          "failedDocuments": { "type": "integer" },
+          "averageConfidence": { "type": "number" },
+          "averageProcessingTimeMs": { "type": "number" },
+          "highQualityDocumentCount": { "type": "integer" },
+          "reviewRequiredCount": { "type": "integer" },
+          "topDocumentTypes": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/DocumentTypeUsage" }
+          },
+          "recentDocuments": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/RecentDocumentInsight" }
+          }
+        }
+      },
+      "DocumentTypeUsage": {
+        "type": "object",
+        "properties": {
+          "documentTypeId": { "type": "string" },
+          "documentTypeName": { "type": "string" },
+          "usageCount": { "type": "integer" },
+          "lastUsed": { "type": "string", "format": "date-time" }
+        }
+      },
+      "RecentDocumentInsight": {
+        "type": "object",
+        "properties": {
+          "fileId": { "type": "string" },
+          "name": { "type": "string" },
+          "status": { "type": "string" },
+          "documentTypeId": { "type": "string" },
+          "completedDate": { "type": "string", "format": "date-time" },
+          "confidence": { "type": "number" }
+        }
+      },
+      "DocumentCollectionSummary": {
+        "type": "object",
+        "properties": {
+          "documentTypeId": { "type": "string" },
+          "documentTypeName": { "type": "string" },
+          "category": { "type": "string" },
+          "documentCount": { "type": "integer" },
+          "averageConfidence": { "type": "number" },
+          "latestDocuments": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/CollectionDocumentSummary" }
+          }
+        }
+      },
+      "CollectionDocumentSummary": {
+        "type": "object",
+        "properties": {
+          "fileId": { "type": "string" },
+          "name": { "type": "string" },
+          "status": { "type": "string" },
+          "uploadDate": { "type": "string", "format": "date-time" },
+          "assignedDate": { "type": "string", "format": "date-time" },
+          "completedDate": { "type": "string", "format": "date-time" }
+        }
+      },
+      "AggregationFeedItem": {
+        "type": "object",
+        "properties": {
+          "fileId": { "type": "string" },
+          "fileName": { "type": "string" },
+          "status": { "type": "string" },
+          "documentTypeId": { "type": "string" },
+          "documentTypeName": { "type": "string" },
+          "confidence": { "type": "number" },
+          "summary": { "type": "string" },
+          "lastUpdated": { "type": "string", "format": "date-time" },
+          "highlights": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      },
+      "ProcessingQueueItem": {
+        "type": "object",
+        "properties": {
+          "fileId": { "type": "string" },
+          "fileName": { "type": "string" },
+          "status": { "type": "string" },
+          "documentTypeId": { "type": "string" },
+          "uploadDate": { "type": "string", "format": "date-time" },
+          "assignedDate": { "type": "string", "format": "date-time" },
+          "completedDate": { "type": "string", "format": "date-time" },
+          "errorMessage": { "type": "string" },
+          "analysisStatus": { "type": "string" },
+          "confidence": { "type": "number" },
+          "progress": { "type": "integer" }
+        }
+      },
+      "ProcessingTimelineEntry": {
+        "type": "object",
+        "properties": {
+          "fileId": { "type": "string" },
+          "fileName": { "type": "string" },
+          "documentTypeId": { "type": "string" },
+          "currentStatus": { "type": "string" },
+          "confidence": { "type": "number" },
+          "errorMessage": { "type": "string" },
+          "steps": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ProcessingTimelineStep" }
+          }
+        }
+      },
+      "ProcessingTimelineStep": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "timestamp": { "type": "string", "format": "date-time" },
+          "state": { "type": "string" },
+          "notes": { "type": "string" }
+        }
+      },
+      "ProcessingRetryRequest": {
+        "type": "object",
+        "properties": {
+          "resetToStage": { "type": "string" },
+          "includeAnalysisReset": { "type": "boolean" }
+        }
+      },
+      "ModelDescriptor": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "provider": { "type": "string" },
+          "displayName": { "type": "string" },
+          "capabilities": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "size": { "type": "string" },
+          "isVisionCapable": { "type": "boolean" },
+          "isInstalled": { "type": "boolean" }
+        }
+      },
+      "InstallModelRequest": {
+        "type": "object",
+        "properties": {
+          "provider": { "type": "string" }
+        }
+      },
+      "ModelInstallationStatus": {
+        "type": "object",
+        "properties": {
+          "installationId": { "type": "string", "format": "uuid" },
+          "provider": { "type": "string" },
+          "modelName": { "type": "string" },
+          "state": { "type": "string" },
+          "progress": { "type": "integer" },
+          "currentStep": { "type": "string" },
+          "enqueuedAt": { "type": "string", "format": "date-time" },
+          "startedAt": { "type": "string", "format": "date-time" },
+          "completedAt": { "type": "string", "format": "date-time" },
+          "lastUpdated": { "type": "string", "format": "date-time" },
+          "errorMessage": { "type": "string" }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add InsightsController with overview, profile, and feed endpoints backed by new aggregation services
- implement ProcessingController diagnostics and retry support alongside queue/timeline helpers
- introduce background model installation queue with ModelsController updates and refreshed Angular/OpenAPI clients

## Testing
- ⚠️ `dotnet build samples/S13.DocMind/S13.DocMind.csproj` *(fails: dotnet command is unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d6f07728788328ac9cf3a9a0b72a80