### PR TITLE
Add DocMind document processing pipeline services

### DIFF
--- a/samples/S13.DocMind/Infrastructure/DocumentPipelineQueue.cs
+++ b/samples/S13.DocMind/Infrastructure/DocumentPipelineQueue.cs
@@ -1,0 +1,254 @@
+using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace S13.DocMind.Infrastructure;
+
+public record ProcessingProfile(string Name, string? TextModel = null, string? VisionModel = null, string? EmbeddingModel = null)
+{
+    public static ProcessingProfile Default(string? embeddingModel = null) => new("default", embeddingModel: embeddingModel);
+}
+
+public sealed class DocumentWorkItem
+{
+    private readonly object _lock = new();
+
+    public DocumentWorkItem(
+        string fileId,
+        string? documentTypeId,
+        ProcessingProfile profile,
+        string? correlationId = null,
+        string? traceId = null,
+        string? spanId = null)
+    {
+        FileId = fileId;
+        DocumentTypeId = documentTypeId;
+        Profile = profile;
+        CorrelationId = correlationId ?? Guid.NewGuid().ToString("N");
+        TraceId = traceId ?? Guid.NewGuid().ToString("N");
+        SpanId = spanId ?? Guid.NewGuid().ToString("N");
+        EnqueuedAt = DateTimeOffset.UtcNow;
+        MaxAttempts = 3;
+    }
+
+    public string FileId { get; }
+    public string? DocumentTypeId { get; }
+    public ProcessingProfile Profile { get; }
+
+    public string CorrelationId { get; }
+    public string TraceId { get; }
+    public string SpanId { get; }
+
+    public int Attempt { get; private set; }
+    public int RetryCount { get; private set; }
+    public int ConsecutiveFailures { get; private set; }
+    public int MaxAttempts { get; internal set; }
+
+    public DateTimeOffset EnqueuedAt { get; }
+    public DateTimeOffset? LastDequeuedAt { get; private set; }
+    public DateTimeOffset? LastAttemptCompletedAt { get; private set; }
+
+    public Dictionary<string, string> Tags { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    public bool CanRetry => RetryCount < MaxAttempts;
+
+    public void MarkDequeued()
+    {
+        lock (_lock)
+        {
+            Attempt++;
+            LastDequeuedAt = DateTimeOffset.UtcNow;
+        }
+    }
+
+    public void MarkAttemptCompleted(bool success)
+    {
+        lock (_lock)
+        {
+            LastAttemptCompletedAt = DateTimeOffset.UtcNow;
+            if (success)
+            {
+                ConsecutiveFailures = 0;
+            }
+            else
+            {
+                ConsecutiveFailures++;
+            }
+        }
+    }
+
+    public int RegisterRetry()
+    {
+        lock (_lock)
+        {
+            RetryCount++;
+            return RetryCount;
+        }
+    }
+
+    public override string ToString()
+        => $"DocumentWorkItem {{ FileId = {FileId}, Attempt = {Attempt}, RetryCount = {RetryCount}, TraceId = {TraceId} }}";
+}
+
+public sealed class DocumentPipelineQueueOptions
+{
+    public int WorkerBatchSize { get; set; } = 4;
+    public int MaxRetryCount { get; set; } = 5;
+    public double BackoffMultiplier { get; set; } = 2.0;
+    public TimeSpan InitialRetryDelay { get; set; } = TimeSpan.FromSeconds(5);
+    public TimeSpan MaxRetryDelay { get; set; } = TimeSpan.FromMinutes(5);
+    public bool UseJitter { get; set; } = true;
+}
+
+public interface IDocumentPipelineQueue
+{
+    ValueTask EnqueueAsync(DocumentWorkItem workItem, CancellationToken ct = default);
+    ValueTask<IReadOnlyList<DocumentWorkItem>> DequeueBatchAsync(int maxItems, CancellationToken ct = default);
+    ValueTask<bool> ScheduleRetryAsync(DocumentWorkItem workItem, Exception reason, CancellationToken ct = default);
+}
+
+public sealed class DocumentPipelineQueue : IDocumentPipelineQueue
+{
+    private readonly Channel<DocumentWorkItem> _channel;
+    private readonly ILogger<DocumentPipelineQueue> _logger;
+    private readonly IOptionsMonitor<DocumentPipelineQueueOptions> _options;
+    private readonly Random _random = new();
+
+    public DocumentPipelineQueue(
+        ILogger<DocumentPipelineQueue> logger,
+        IOptionsMonitor<DocumentPipelineQueueOptions> options)
+    {
+        _logger = logger;
+        _options = options;
+        var channelOptions = new BoundedChannelOptions(capacity: 500)
+        {
+            AllowSynchronousContinuations = false,
+            FullMode = BoundedChannelFullMode.Wait,
+            SingleReader = false,
+            SingleWriter = false
+        };
+        _channel = Channel.CreateBounded<DocumentWorkItem>(channelOptions);
+    }
+
+    public async ValueTask EnqueueAsync(DocumentWorkItem workItem, CancellationToken ct = default)
+    {
+        var opts = _options.CurrentValue;
+        workItem.MaxAttempts = Math.Max(opts.MaxRetryCount, workItem.MaxAttempts);
+        _logger.LogDebug("Queueing document {DocumentId} for processing (trace: {TraceId})", workItem.FileId, workItem.TraceId);
+        await _channel.Writer.WriteAsync(workItem, ct);
+    }
+
+    public async ValueTask<IReadOnlyList<DocumentWorkItem>> DequeueBatchAsync(int maxItems, CancellationToken ct = default)
+    {
+        if (maxItems <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxItems), "Batch size must be greater than zero.");
+        }
+
+        var items = new List<DocumentWorkItem>(maxItems);
+
+        while (!ct.IsCancellationRequested && items.Count < maxItems)
+        {
+            DocumentWorkItem? item = null;
+            if (items.Count == 0)
+            {
+                try
+                {
+                    item = await _channel.Reader.ReadAsync(ct);
+                }
+                catch (ChannelClosedException)
+                {
+                    break;
+                }
+            }
+            else if (_channel.Reader.TryRead(out item))
+            {
+                // already populated
+            }
+
+            if (item == null)
+            {
+                break;
+            }
+
+            item.MarkDequeued();
+            items.Add(item);
+        }
+
+        return items;
+    }
+
+    public async ValueTask<bool> ScheduleRetryAsync(DocumentWorkItem workItem, Exception reason, CancellationToken ct = default)
+    {
+        var attempt = workItem.RegisterRetry();
+        var opts = _options.CurrentValue;
+        if (attempt > opts.MaxRetryCount)
+        {
+            _logger.LogWarning(
+                reason,
+                "Dropping document {DocumentId} after exhausting {RetryCount} retries (trace: {TraceId})",
+                workItem.FileId,
+                opts.MaxRetryCount,
+                workItem.TraceId);
+            return false;
+        }
+
+        var delay = CalculateBackoffDelay(attempt - 1, opts);
+        _logger.LogInformation(
+            reason,
+            "Scheduling retry {RetryCount}/{MaxRetry} for document {DocumentId} in {Delay} (trace: {TraceId})",
+            attempt,
+            opts.MaxRetryCount,
+            workItem.FileId,
+            delay,
+            workItem.TraceId);
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await Task.Delay(delay, ct);
+                await EnqueueAsync(workItem, ct);
+            }
+            catch (OperationCanceledException)
+            {
+                // shutting down; ignore
+            }
+        }, CancellationToken.None);
+
+        return true;
+    }
+
+    private TimeSpan CalculateBackoffDelay(int retryNumber, DocumentPipelineQueueOptions opts)
+    {
+        var baseDelay = opts.InitialRetryDelay;
+        if (retryNumber <= 0)
+        {
+            return ApplyJitter(baseDelay, opts);
+        }
+
+        var multiplier = Math.Pow(opts.BackoffMultiplier, retryNumber);
+        var delay = TimeSpan.FromMilliseconds(baseDelay.TotalMilliseconds * multiplier);
+        if (delay > opts.MaxRetryDelay)
+        {
+            delay = opts.MaxRetryDelay;
+        }
+
+        return ApplyJitter(delay, opts);
+    }
+
+    private TimeSpan ApplyJitter(TimeSpan delay, DocumentPipelineQueueOptions opts)
+    {
+        if (!opts.UseJitter || delay <= TimeSpan.Zero)
+        {
+            return delay;
+        }
+
+        lock (_random)
+        {
+            var jitterFactor = _random.NextDouble() * 0.3 + 0.85; // +/-15%
+            var jittered = TimeSpan.FromMilliseconds(delay.TotalMilliseconds * jitterFactor);
+            return jittered <= opts.MaxRetryDelay ? jittered : opts.MaxRetryDelay;
+        }
+    }
+}

--- a/samples/S13.DocMind/Program.cs
+++ b/samples/S13.DocMind/Program.cs
@@ -3,6 +3,7 @@ using Koan.Core.Modules;
 using Koan.Core.Observability;
 using Koan.Data.Core;
 using Koan.Web.Extensions;
+using S13.DocMind.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -11,6 +12,9 @@ builder.Services.AddKoan();
 
 // Add Koan observability for proper startup sequence logging
 builder.Services.AddKoanObservability();
+
+// Register DocMind-specific processing pipeline
+builder.Services.AddDocMindProcessing(builder.Configuration);
 
 // Note: Service implementations are handled by Koan auto-registration
 

--- a/samples/S13.DocMind/Services/DocMindRegistrar.cs
+++ b/samples/S13.DocMind/Services/DocMindRegistrar.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using S13.DocMind.Infrastructure;
+
+namespace S13.DocMind.Services;
+
+public static class DocMindRegistrar
+{
+    private const string QueueSection = "S13:DocMind:Processing:Queue";
+    private const string PipelineSection = "S13:DocMind:Processing:Pipeline";
+
+    public static IServiceCollection AddDocMindProcessing(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.Configure<DocumentPipelineQueueOptions>(configuration.GetSection(QueueSection));
+        services.Configure<DocumentAnalysisOptions>(configuration.GetSection(PipelineSection));
+
+        services.AddSingleton<IDocumentPipelineQueue, DocumentPipelineQueue>();
+        services.AddSingleton<IDocumentProcessingEventSink, DocumentProcessingEventLogger>();
+        services.AddSingleton<ITemplateGeneratorService, TemplateGeneratorService>();
+        services.AddSingleton<IVisionInsightService, VisionInsightService>();
+        services.AddSingleton<IInsightAggregationService, InsightAggregationService>();
+        services.AddSingleton<DocumentAnalysisPipeline>();
+        services.AddHostedService<DocumentProcessingHostedService>();
+
+        return services;
+    }
+}

--- a/samples/S13.DocMind/Services/DocumentAnalysisPipeline.cs
+++ b/samples/S13.DocMind/Services/DocumentAnalysisPipeline.cs
@@ -1,0 +1,257 @@
+using System.Linq;
+using Koan.AI.Contracts;
+using Koan.AI.Contracts.Models;
+using Koan.Data.Core;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using S13.DocMind.Infrastructure;
+using S13.DocMind.Models;
+
+namespace S13.DocMind.Services;
+
+public sealed class DocumentAnalysisOptions
+{
+    public int BatchSize { get; set; } = 4;
+    public string EmbeddingModel { get; set; } = "text-embedding-3-large";
+    public bool EnableVisionInsights { get; set; } = true;
+    public bool RecordDiagnostics { get; set; } = true;
+}
+
+public sealed class TransientDocumentProcessingException : Exception
+{
+    public TransientDocumentProcessingException(string message, Exception? inner = null)
+        : base(message, inner)
+    {
+    }
+}
+
+public sealed class DocumentAnalysisPipeline
+{
+    private readonly IAi _ai;
+    private readonly ILogger<DocumentAnalysisPipeline> _logger;
+    private readonly IOptionsMonitor<DocumentAnalysisOptions> _options;
+    private readonly IDocumentPipelineQueue _queue;
+    private readonly IVisionInsightService _visionInsights;
+    private readonly ITemplateGeneratorService _templateGenerator;
+    private readonly IInsightAggregationService _aggregationService;
+    private readonly IDocumentProcessingEventSink _eventSink;
+
+    public DocumentAnalysisPipeline(
+        IAi ai,
+        ILogger<DocumentAnalysisPipeline> logger,
+        IOptionsMonitor<DocumentAnalysisOptions> options,
+        IDocumentPipelineQueue queue,
+        IVisionInsightService visionInsights,
+        ITemplateGeneratorService templateGenerator,
+        IInsightAggregationService aggregationService,
+        IDocumentProcessingEventSink eventSink)
+    {
+        _ai = ai;
+        _logger = logger;
+        _options = options;
+        _queue = queue;
+        _visionInsights = visionInsights;
+        _templateGenerator = templateGenerator;
+        _aggregationService = aggregationService;
+        _eventSink = eventSink;
+    }
+
+    public async Task ProcessBatchAsync(IReadOnlyList<DocumentWorkItem> workItems, CancellationToken ct)
+    {
+        if (workItems.Count == 0)
+        {
+            return;
+        }
+
+        var pipelineOptions = _options.CurrentValue;
+        var prepared = new List<(DocumentWorkItem WorkItem, File File, DocumentType? Type, TemplateDefinition Template, VisionInsightResult? Vision, AggregatedInsights Aggregated)>();
+
+        foreach (var workItem in workItems)
+        {
+            ct.ThrowIfCancellationRequested();
+            _eventSink.Record(new DocumentProcessingEvent(workItem.FileId, "dequeue", "started", workItem.TraceId, workItem.CorrelationId, workItem.Attempt));
+
+            try
+            {
+                var file = await File.Get(workItem.FileId);
+                if (file is null)
+                {
+                    _eventSink.Record(new DocumentProcessingEvent(workItem.FileId, "hydrate", "missing", workItem.TraceId, workItem.CorrelationId, workItem.Attempt));
+                    continue;
+                }
+
+                if (string.IsNullOrWhiteSpace(file.DocumentTypeId))
+                {
+                    _eventSink.Record(new DocumentProcessingEvent(workItem.FileId, "hydrate", "no-type", workItem.TraceId, workItem.CorrelationId, workItem.Attempt));
+                    continue;
+                }
+
+                var docType = await DocumentType.Get(file.DocumentTypeId);
+                var template = await _templateGenerator.ResolveTemplateAsync(docType, ct);
+                VisionInsightResult? vision = null;
+                if (pipelineOptions.EnableVisionInsights)
+                {
+                    vision = await _visionInsights.TryExtractAsync(file, ct);
+                }
+
+                file.Status = "analyzing";
+                file.Metadata["analysisProfile"] = workItem.Profile.Name;
+                await file.Save(ct);
+
+                var aggregated = await _aggregationService.AggregateAsync(file, template, vision, ct);
+
+                prepared.Add((workItem, file, docType, template, vision, aggregated));
+                _eventSink.Record(new DocumentProcessingEvent(workItem.FileId, "aggregate", "prepared", workItem.TraceId, workItem.CorrelationId, workItem.Attempt));
+            }
+            catch (TransientDocumentProcessingException tex)
+            {
+                await HandleTransientFailureAsync(workItem, tex, ct);
+            }
+            catch (Exception ex)
+            {
+                await HandleFailureAsync(workItem, ex, ct);
+            }
+        }
+
+        if (prepared.Count == 0)
+        {
+            return;
+        }
+
+        var embeddingTargets = prepared
+            .Select((entry, idx) => (Entry: entry, Index: idx))
+            .Where(tuple => !string.IsNullOrWhiteSpace(tuple.Entry.Aggregated.EmbeddingText))
+            .ToList();
+
+        var embeddingInputs = embeddingTargets
+            .Select(tuple => tuple.Entry.Aggregated.EmbeddingText)
+            .Where(text => !string.IsNullOrWhiteSpace(text))
+            .ToList();
+
+        var embeddingMap = new Dictionary<int, float[]>();
+        if (embeddingInputs.Count > 0 && !string.IsNullOrWhiteSpace(pipelineOptions.EmbeddingModel))
+        {
+            try
+            {
+                var response = await _ai.EmbedAsync(new AiEmbeddingsRequest
+                {
+                    Input = embeddingInputs,
+                    Model = pipelineOptions.EmbeddingModel
+                }, ct);
+                for (var i = 0; i < embeddingTargets.Count && i < response.Vectors.Count; i++)
+                {
+                    embeddingMap[embeddingTargets[i].Index] = response.Vectors[i];
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Embedding batch failed for {Count} documents", embeddingInputs.Count);
+            }
+        }
+
+        for (var index = 0; index < prepared.Count; index++)
+        {
+            var entry = prepared[index];
+            var workItem = entry.WorkItem;
+            try
+            {
+                embeddingMap.TryGetValue(index, out var embedding);
+                await PersistAnalysisAsync(entry, embedding, ct);
+                workItem.MarkAttemptCompleted(success: true);
+                _eventSink.Record(new DocumentProcessingEvent(workItem.FileId, "persist", "completed", workItem.TraceId, workItem.CorrelationId, workItem.Attempt));
+            }
+            catch (TransientDocumentProcessingException tex)
+            {
+                workItem.MarkAttemptCompleted(success: false);
+                await HandleTransientFailureAsync(workItem, tex, ct);
+            }
+            catch (Exception ex)
+            {
+                workItem.MarkAttemptCompleted(success: false);
+                await HandleFailureAsync(workItem, ex, ct);
+            }
+        }
+    }
+
+    private async Task PersistAnalysisAsync(
+        (DocumentWorkItem WorkItem, File File, DocumentType? Type, TemplateDefinition Template, VisionInsightResult? Vision, AggregatedInsights Aggregated) context,
+        float[]? embedding,
+        CancellationToken ct)
+    {
+        var file = context.File;
+        var workItem = context.WorkItem;
+        var aggregated = context.Aggregated;
+
+        var analysis = new Analysis
+        {
+            FileId = file.Id!,
+            FileName = file.Name,
+            DocumentTypeId = context.Type?.Id ?? file.DocumentTypeId ?? string.Empty,
+            DocumentTypeName = context.Type?.Name ?? "Unassigned",
+            Status = "completed",
+            StartedDate = workItem.LastDequeuedAt?.UtcDateTime ?? DateTime.UtcNow,
+            CompletedDate = DateTime.UtcNow,
+            OverallConfidence = aggregated.FieldConfidences.Values.DefaultIfEmpty(0.5).Average(),
+            ExtractedData = aggregated.StructuredData,
+            FieldConfidences = aggregated.FieldConfidences,
+            RawAIResponse = aggregated.Summary,
+            ProcessingMetadata = new Dictionary<string, object>
+            {
+                ["traceId"] = workItem.TraceId,
+                ["correlationId"] = workItem.CorrelationId,
+                ["profile"] = workItem.Profile.Name,
+                ["attempt"] = workItem.Attempt
+            }
+        };
+
+        if (embedding is not null)
+        {
+            analysis.ProcessingMetadata["embedding"] = embedding;
+            analysis.ProcessingMetadata["embeddingModel"] = _options.CurrentValue.EmbeddingModel;
+        }
+
+        if (_options.CurrentValue.RecordDiagnostics)
+        {
+            foreach (var diagnostic in aggregated.Diagnostics)
+            {
+                analysis.ProcessingMetadata[$"diag.{diagnostic.Key}"] = diagnostic.Value;
+            }
+        }
+
+        await analysis.Save(ct);
+
+        file.AnalysisId = analysis.Id;
+        file.Status = "completed";
+        file.CompletedDate = DateTime.UtcNow;
+        file.Metadata["analysisTraceId"] = workItem.TraceId;
+        file.Metadata["analysisProfile"] = workItem.Profile.Name;
+        await file.Save(ct);
+    }
+
+    private async Task HandleTransientFailureAsync(DocumentWorkItem workItem, Exception exception, CancellationToken ct)
+    {
+        _eventSink.Record(new DocumentProcessingEvent(workItem.FileId, "pipeline", "transient", workItem.TraceId, workItem.CorrelationId, workItem.Attempt, Exception: exception));
+        var requeued = await _queue.ScheduleRetryAsync(workItem, exception, ct);
+        if (!requeued)
+        {
+            await HandleFailureAsync(workItem, exception, ct, isTerminal: true);
+        }
+    }
+
+    private async Task HandleFailureAsync(DocumentWorkItem workItem, Exception exception, CancellationToken ct, bool isTerminal = false)
+    {
+        _logger.LogError(exception, "Document {DocumentId} processing failed", workItem.FileId);
+        _eventSink.Record(new DocumentProcessingEvent(workItem.FileId, "pipeline", isTerminal ? "failed" : "error", workItem.TraceId, workItem.CorrelationId, workItem.Attempt, Exception: exception));
+
+        var file = await File.Get(workItem.FileId);
+        if (file is null)
+        {
+            return;
+        }
+
+        file.Status = "failed";
+        file.ErrorMessage = exception.Message;
+        file.LastErrorDate = DateTime.UtcNow;
+        await file.Save(ct);
+    }
+}

--- a/samples/S13.DocMind/Services/DocumentProcessingEvents.cs
+++ b/samples/S13.DocMind/Services/DocumentProcessingEvents.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.Logging;
+
+namespace S13.DocMind.Services;
+
+public record DocumentProcessingEvent(
+    string DocumentId,
+    string Stage,
+    string Status,
+    string TraceId,
+    string CorrelationId,
+    int Attempt,
+    IDictionary<string, object>? Data = null,
+    Exception? Exception = null,
+    DateTimeOffset? Timestamp = null)
+{
+    public DateTimeOffset OccurredAt => Timestamp ?? DateTimeOffset.UtcNow;
+}
+
+public interface IDocumentProcessingEventSink
+{
+    void Record(DocumentProcessingEvent evt);
+}
+
+public sealed class DocumentProcessingEventLogger : IDocumentProcessingEventSink
+{
+    private readonly ILogger<DocumentProcessingEventLogger> _logger;
+
+    public DocumentProcessingEventLogger(ILogger<DocumentProcessingEventLogger> logger)
+    {
+        _logger = logger;
+    }
+
+    public void Record(DocumentProcessingEvent evt)
+    {
+        var level = evt.Exception is null ? LogLevel.Information : LogLevel.Error;
+        if (_logger.IsEnabled(level))
+        {
+            using (_logger.BeginScope(new Dictionary<string, object>
+            {
+                ["docId"] = evt.DocumentId,
+                ["stage"] = evt.Stage,
+                ["status"] = evt.Status,
+                ["traceId"] = evt.TraceId,
+                ["correlationId"] = evt.CorrelationId,
+                ["attempt"] = evt.Attempt
+            }))
+            {
+                _logger.Log(level,
+                    evt.Exception,
+                    "Document {DocumentId} {Stage} stage recorded {Status}",
+                    evt.DocumentId,
+                    evt.Stage,
+                    evt.Status);
+            }
+        }
+    }
+}

--- a/samples/S13.DocMind/Services/DocumentProcessingHostedService.cs
+++ b/samples/S13.DocMind/Services/DocumentProcessingHostedService.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using S13.DocMind.Infrastructure;
+
+namespace S13.DocMind.Services;
+
+public sealed class DocumentProcessingHostedService : BackgroundService
+{
+    private readonly IDocumentPipelineQueue _queue;
+    private readonly DocumentAnalysisPipeline _pipeline;
+    private readonly IOptionsMonitor<DocumentPipelineQueueOptions> _queueOptions;
+    private readonly ILogger<DocumentProcessingHostedService> _logger;
+
+    public DocumentProcessingHostedService(
+        IDocumentPipelineQueue queue,
+        DocumentAnalysisPipeline pipeline,
+        IOptionsMonitor<DocumentPipelineQueueOptions> queueOptions,
+        ILogger<DocumentProcessingHostedService> logger)
+    {
+        _queue = queue;
+        _pipeline = pipeline;
+        _queueOptions = queueOptions;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Document processing hosted service started");
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var batchSize = Math.Max(1, _queueOptions.CurrentValue.WorkerBatchSize);
+                var batch = await _queue.DequeueBatchAsync(batchSize, stoppingToken);
+                if (batch.Count == 0)
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(1), stoppingToken);
+                    continue;
+                }
+
+                await _pipeline.ProcessBatchAsync(batch, stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                // graceful shutdown
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unhandled exception in document processing loop");
+                await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+            }
+        }
+
+        _logger.LogInformation("Document processing hosted service stopped");
+    }
+}

--- a/samples/S13.DocMind/Services/InsightAggregationService.cs
+++ b/samples/S13.DocMind/Services/InsightAggregationService.cs
@@ -1,0 +1,110 @@
+using System.Text;
+using S13.DocMind.Models;
+
+namespace S13.DocMind.Services;
+
+public record AggregatedInsights(
+    string Summary,
+    string EmbeddingText,
+    IDictionary<string, object> StructuredData,
+    IDictionary<string, double> FieldConfidences,
+    IDictionary<string, object> Diagnostics)
+{
+    public static AggregatedInsights Empty => new(
+        Summary: string.Empty,
+        EmbeddingText: string.Empty,
+        StructuredData: new Dictionary<string, object>(),
+        FieldConfidences: new Dictionary<string, double>(),
+        Diagnostics: new Dictionary<string, object>());
+}
+
+public interface IInsightAggregationService
+{
+    Task<AggregatedInsights> AggregateAsync(
+        File file,
+        TemplateDefinition template,
+        VisionInsightResult? visionResult,
+        CancellationToken ct = default);
+}
+
+public sealed class InsightAggregationService : IInsightAggregationService
+{
+    public Task<AggregatedInsights> AggregateAsync(
+        File file,
+        TemplateDefinition template,
+        VisionInsightResult? visionResult,
+        CancellationToken ct = default)
+    {
+        if (file is null)
+        {
+            throw new ArgumentNullException(nameof(file));
+        }
+
+        var summaryBuilder = new StringBuilder();
+        var embeddingBuilder = new StringBuilder();
+        var structured = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+        var confidences = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+        var diagnostics = new Dictionary<string, object>
+        {
+            ["extractedTextLength"] = file.ExtractedText?.Length ?? 0,
+            ["templateName"] = template.Name,
+            ["visionEnabled"] = visionResult is not null
+        };
+
+        if (!string.IsNullOrWhiteSpace(file.ExtractedText))
+        {
+            summaryBuilder.AppendLine(file.ExtractedText!.Trim());
+            embeddingBuilder.AppendLine(file.ExtractedText.Trim());
+        }
+
+        if (visionResult is not null)
+        {
+            summaryBuilder.AppendLine();
+            summaryBuilder.AppendLine("# Vision Insights");
+            summaryBuilder.AppendLine(visionResult.Narrative);
+            foreach (var obs in visionResult.Observations)
+            {
+                summaryBuilder.AppendLine($"- {obs.Label} ({obs.Confidence:P0})");
+            }
+
+            foreach (var hint in visionResult.FieldHints)
+            {
+                if (!confidences.ContainsKey(hint.Key))
+                {
+                    confidences[hint.Key] = hint.Value;
+                }
+            }
+
+            foreach (var kvp in visionResult.Diagnostics)
+            {
+                diagnostics[$"vision.{kvp.Key}"] = kvp.Value;
+            }
+        }
+
+        foreach (var field in template.Fields)
+        {
+            if (!structured.ContainsKey(field.Name))
+            {
+                structured[field.Name] = string.Empty;
+                confidences.TryAdd(field.Name, field.Required ? 0.5 : 0.2);
+            }
+        }
+
+        if (visionResult is not null)
+        {
+            foreach (var obs in visionResult.Observations)
+            {
+                var key = $"vision.{obs.Label}";
+                structured[key] = obs.Metadata ?? new Dictionary<string, object>();
+                confidences[key] = obs.Confidence;
+            }
+        }
+
+        return Task.FromResult(new AggregatedInsights(
+            Summary: summaryBuilder.ToString().Trim(),
+            EmbeddingText: embeddingBuilder.ToString().Trim(),
+            StructuredData: structured,
+            FieldConfidences: confidences,
+            Diagnostics: diagnostics));
+    }
+}

--- a/samples/S13.DocMind/Services/TemplateGeneratorService.cs
+++ b/samples/S13.DocMind/Services/TemplateGeneratorService.cs
@@ -1,0 +1,82 @@
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using S13.DocMind.Models;
+
+namespace S13.DocMind.Services;
+
+public record TemplateField(string Name, string Description, bool Required, string DataType = "string");
+
+public record TemplateDefinition(
+    string Name,
+    string? Description,
+    IReadOnlyList<TemplateField> Fields,
+    IDictionary<string, object> Metadata)
+{
+    public static TemplateDefinition Empty { get; } = new(
+        Name: "default",
+        Description: "Default free-form analysis template",
+        Fields: Array.Empty<TemplateField>(),
+        Metadata: new Dictionary<string, object>());
+}
+
+public interface ITemplateGeneratorService
+{
+    Task<TemplateDefinition> ResolveTemplateAsync(DocumentType? type, CancellationToken ct = default);
+}
+
+public sealed class TemplateGeneratorService : ITemplateGeneratorService
+{
+    private readonly ILogger<TemplateGeneratorService> _logger;
+
+    public TemplateGeneratorService(ILogger<TemplateGeneratorService> logger)
+    {
+        _logger = logger;
+    }
+
+    public Task<TemplateDefinition> ResolveTemplateAsync(DocumentType? type, CancellationToken ct = default)
+    {
+        if (type is null)
+        {
+            _logger.LogDebug("Falling back to default template definition because no document type was assigned.");
+            return Task.FromResult(TemplateDefinition.Empty);
+        }
+
+        var metadata = new Dictionary<string, object>(type.ModelSettings, StringComparer.OrdinalIgnoreCase)
+        {
+            ["prompt"] = type.AnalysisPrompt,
+            ["requiredFields"] = type.RequiredFields,
+            ["optionalFields"] = type.OptionalFields
+        };
+
+        var fields = new List<TemplateField>();
+        foreach (var field in type.RequiredFields)
+        {
+            fields.Add(new TemplateField(field, "Required field identified in template", required: true));
+        }
+
+        foreach (var field in type.OptionalFields)
+        {
+            if (fields.All(f => !string.Equals(f.Name, field, StringComparison.OrdinalIgnoreCase)))
+            {
+                fields.Add(new TemplateField(field, "Optional field identified in template", required: false));
+            }
+        }
+
+        if (type.ExtractionSchema is { Count: > 0 })
+        {
+            foreach (var kvp in type.ExtractionSchema)
+            {
+                var required = type.RequiredFields.Any(f => string.Equals(f, kvp.Key, StringComparison.OrdinalIgnoreCase));
+                fields.Add(new TemplateField(kvp.Key, "Schema defined field", required, kvp.Value?.ToString() ?? "string"));
+            }
+        }
+
+        var template = new TemplateDefinition(
+            Name: type.Name,
+            Description: type.Description,
+            Fields: fields,
+            Metadata: metadata);
+
+        return Task.FromResult(template);
+    }
+}

--- a/samples/S13.DocMind/Services/VisionInsightService.cs
+++ b/samples/S13.DocMind/Services/VisionInsightService.cs
@@ -1,0 +1,105 @@
+using Microsoft.Extensions.Logging;
+using S13.DocMind.Models;
+
+namespace S13.DocMind.Services;
+
+public record VisionObservation(string Label, double Confidence, IDictionary<string, object>? Metadata = null);
+
+public record VisionInsightResult(
+    string Narrative,
+    IReadOnlyList<VisionObservation> Observations,
+    IDictionary<string, double> FieldHints,
+    IDictionary<string, object> Diagnostics)
+{
+    public static VisionInsightResult Empty => new(
+        Narrative: string.Empty,
+        Observations: Array.Empty<VisionObservation>(),
+        FieldHints: new Dictionary<string, double>(),
+        Diagnostics: new Dictionary<string, object>());
+}
+
+public interface IVisionInsightService
+{
+    Task<VisionInsightResult?> TryExtractAsync(File file, CancellationToken ct = default);
+}
+
+public sealed class VisionInsightService : IVisionInsightService
+{
+    private static readonly HashSet<string> VisionContentTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "image/jpeg",
+        "image/png",
+        "image/gif",
+        "image/bmp",
+        "image/webp"
+    };
+
+    private readonly ILogger<VisionInsightService> _logger;
+
+    public VisionInsightService(ILogger<VisionInsightService> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<VisionInsightResult?> TryExtractAsync(File file, CancellationToken ct = default)
+    {
+        if (!ShouldProcess(file))
+        {
+            return null;
+        }
+
+        try
+        {
+            await using var stream = System.IO.File.OpenRead(file.FilePath);
+            using var image = await SixLabors.ImageSharp.Image.LoadAsync(stream, ct);
+
+            var diagnostics = new Dictionary<string, object>
+            {
+                ["width"] = image.Width,
+                ["height"] = image.Height,
+                ["pixelFormat"] = image.PixelType.BitsPerPixel,
+                ["sizeBytes"] = file.Size
+            };
+
+            var observations = new List<VisionObservation>
+            {
+                new("document", 0.6, new Dictionary<string, object>
+                {
+                    ["aspectRatio"] = Math.Round(image.Width / (double)image.Height, 2)
+                })
+            };
+
+            var fieldHints = new Dictionary<string, double>
+            {
+                ["layout.visualDensity"] = Math.Clamp(image.Width * image.Height / 1_000_000d, 0, 1)
+            };
+
+            return new VisionInsightResult(
+                Narrative: $"Vision scan completed for {file.Name} ({image.Width}x{image.Height}).",
+                Observations: observations,
+                FieldHints: fieldHints,
+                Diagnostics: diagnostics);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Unable to run lightweight vision insight extraction for {FileId}", file.Id);
+            return VisionInsightResult.Empty;
+        }
+    }
+
+    private static bool ShouldProcess(File file)
+    {
+        if (string.IsNullOrEmpty(file.ContentType))
+        {
+            return false;
+        }
+
+        if (VisionContentTypes.Contains(file.ContentType))
+        {
+            return true;
+        }
+
+        var extension = System.IO.Path.GetExtension(file.FilePath);
+        return extension is ".png" or ".jpg" or ".jpeg" or ".gif" or ".bmp" or ".webp";
+    }
+}

--- a/samples/S13.DocMind/appsettings.Development.json
+++ b/samples/S13.DocMind/appsettings.Development.json
@@ -17,7 +17,23 @@
     "DocMind": {
       "StorageRoot": "./storage/dev",
       "EnableDetailedLogging": true,
-      "DebugMode": true
+      "DebugMode": true,
+      "Processing": {
+        "Queue": {
+          "WorkerBatchSize": 2,
+          "MaxRetryCount": 3,
+          "InitialRetryDelay": "00:00:02",
+          "BackoffMultiplier": 2.0,
+          "MaxRetryDelay": "00:01:00",
+          "UseJitter": true
+        },
+        "Pipeline": {
+          "BatchSize": 2,
+          "EmbeddingModel": "text-embedding-3-large",
+          "EnableVisionInsights": true,
+          "RecordDiagnostics": true
+        }
+      }
     }
   }
 }

--- a/samples/S13.DocMind/appsettings.json
+++ b/samples/S13.DocMind/appsettings.json
@@ -28,7 +28,23 @@
         "image/png",
         "image/gif",
         "image/bmp"
-      ]
+      ],
+      "Processing": {
+        "Queue": {
+          "WorkerBatchSize": 4,
+          "MaxRetryCount": 5,
+          "InitialRetryDelay": "00:00:05",
+          "BackoffMultiplier": 2.0,
+          "MaxRetryDelay": "00:05:00",
+          "UseJitter": true
+        },
+        "Pipeline": {
+          "BatchSize": 4,
+          "EmbeddingModel": "text-embedding-3-large",
+          "EnableVisionInsights": true,
+          "RecordDiagnostics": true
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- add a configurable document pipeline queue with enriched work items for retries and tracing
- implement vision, template, aggregation, and analysis pipeline services along with hosted processing worker and event logging
- wire DocMind processing services into the app configuration and startup options

## Testing
- `dotnet build` *(fails: .NET SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d6f05fa7e88328b39bbaf3d5aaabff